### PR TITLE
fix: seed discovery reads email from DB settings (#57)

### DIFF
--- a/R/mod_seed_discovery.R
+++ b/R/mod_seed_discovery.R
@@ -59,9 +59,10 @@ mod_seed_discovery_server <- function(id, con, config) {
         return()
       }
 
-      # Get config values
+      # Get config values — prefer DB settings, fall back to config file
       cfg <- config()
-      email <- get_setting(cfg, "openalex", "email")
+      email <- get_db_setting(con(), "openalex_email") %||%
+               get_setting(cfg, "openalex", "email")
       api_key <- get_setting(cfg, "openalex", "api_key")
 
       if (is.null(email) || nchar(email) == 0) {


### PR DESCRIPTION
## Summary
- Seed discovery module only read OpenAlex email from `config.yml`, missing emails saved via the Settings page (stored in DB)
- Now checks DB settings first, falling back to config file — matching the pattern used in `mod_settings.R`

## Test plan
- [ ] Configure email only via Settings page (no config.yml), use "Discover from Paper" — should work without prompting