### PR TITLE
feat: v13: Search & Discovery — Research Refiner + keyword filtering

### DIFF
--- a/R/_ragnar.R
+++ b/R/_ragnar.R
@@ -796,7 +796,7 @@ rebuild_notebook_store <- function(notebook_id, con = NULL, api_key, embed_model
       }
     }
 
-    # Re-embed all abstracts
+    # Re-embed all abstracts (skip those with NA/empty abstract text)
     if (nrow(abstracts) > 0) {
       for (i in seq_len(nrow(abstracts))) {
         # Check for cancellation before each item
@@ -807,6 +807,12 @@ rebuild_notebook_store <- function(notebook_id, con = NULL, api_key, embed_model
         }
 
         abstract <- abstracts[i, ]
+
+        # Skip abstracts without text (e.g., BibTeX imports without abstracts)
+        if (is.na(abstract$abstract) || nchar(trimws(abstract$abstract)) == 0) {
+          count <- count + 1
+          next
+        }
 
         # Derive human-readable item name for progress display
         item_name <- if (!is.null(abstract$title) && !is.na(abstract$title) && nchar(abstract$title) > 0) {

--- a/R/cost_tracking.R
+++ b/R/cost_tracking.R
@@ -39,7 +39,8 @@ COST_OPERATION_META <- list(
   "research_questions" = list(label = "Research Questions", icon_fun = "icon_lightbulb", accent_class = "text-warning"),
   "lit_review_table" = list(label = "Literature Review Table", icon_fun = "icon_table", accent_class = "text-success"),
   "methodology_extractor" = list(label = "Methodology Extractor", icon_fun = "icon_flask", accent_class = "text-danger"),
-  "gap_analysis" = list(label = "Gap Analysis", icon_fun = "icon_search", accent_class = "text-info")
+  "gap_analysis" = list(label = "Gap Analysis", icon_fun = "icon_search", accent_class = "text-info"),
+  "refiner_eval" = list(label = "Research Refiner", icon_fun = "icon_funnel", accent_class = "text-warning")
 )
 
 KNOWN_MODEL_LABELS <- c(

--- a/R/db.R
+++ b/R/db.R
@@ -312,6 +312,10 @@ init_schema <- function(con) {
     )
   ")
 
+  dbExecute(con, "
+    CREATE INDEX IF NOT EXISTS idx_refiner_results_run_id ON refiner_results(run_id)
+  ")
+
   # Migration: Fix retraction_date column type (DATE -> VARCHAR) if needed
   # This handles the case where the table was created with DATE type
   tryCatch({

--- a/R/db.R
+++ b/R/db.R
@@ -267,6 +267,51 @@ init_schema <- function(con) {
     )
   ")
 
+  # Research refiner tables
+  dbExecute(con, "
+    CREATE TABLE IF NOT EXISTS refiner_runs (
+      id VARCHAR PRIMARY KEY,
+      anchor_type VARCHAR NOT NULL,
+      anchor_intent VARCHAR,
+      anchor_seed_ids VARCHAR,
+      source_type VARCHAR NOT NULL,
+      source_notebook_id VARCHAR,
+      mode VARCHAR DEFAULT 'discovery',
+      weights VARCHAR,
+      status VARCHAR DEFAULT 'running',
+      total_candidates INTEGER DEFAULT 0,
+      scored_count INTEGER DEFAULT 0,
+      created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+      completed_at TIMESTAMP
+    )
+  ")
+
+  dbExecute(con, "
+    CREATE TABLE IF NOT EXISTS refiner_results (
+      id VARCHAR PRIMARY KEY,
+      run_id VARCHAR NOT NULL,
+      paper_id VARCHAR NOT NULL,
+      title VARCHAR,
+      authors VARCHAR,
+      abstract VARCHAR,
+      year INTEGER,
+      venue VARCHAR,
+      doi VARCHAR,
+      cited_by_count INTEGER DEFAULT 0,
+      fwci DOUBLE,
+      seed_connectivity DOUBLE DEFAULT 0,
+      bridge_score DOUBLE DEFAULT 0,
+      citation_velocity DOUBLE DEFAULT 0,
+      ubiquity_penalty DOUBLE DEFAULT 0,
+      utility_score DOUBLE DEFAULT 0,
+      embedding_similarity DOUBLE,
+      llm_utility_score DOUBLE,
+      llm_rationale VARCHAR,
+      user_action VARCHAR DEFAULT 'pending',
+      FOREIGN KEY (run_id) REFERENCES refiner_runs(id)
+    )
+  ")
+
   # Migration: Fix retraction_date column type (DATE -> VARCHAR) if needed
   # This handles the case where the table was created with DATE type
   tryCatch({
@@ -1955,4 +2000,145 @@ check_audit_imports <- function(con, run_id, notebook_id) {
       AND work_id IN (SELECT paper_id FROM abstracts WHERE notebook_id = ?)
   ", list(run_id, notebook_id))
   invisible(TRUE)
+}
+
+# ---- Research Refiner DB Helpers ----
+
+#' Create a new refiner run
+#' @param con DuckDB connection
+#' @param anchor_type Character: "seeds", "intent", or "both"
+#' @param source_type Character: "notebook" or "fetch"
+#' @param anchor_intent Optional natural language intent
+#' @param anchor_seed_ids Optional JSON array of seed paper IDs
+#' @param source_notebook_id Optional source notebook ID
+#' @param mode Scoring mode: "discovery", "comprehensive", "emerging", "custom"
+#' @param weights JSON string of weight configuration
+#' @return Run ID
+create_refiner_run <- function(con, anchor_type, source_type,
+                                anchor_intent = NULL, anchor_seed_ids = NULL,
+                                source_notebook_id = NULL, mode = "discovery",
+                                weights = NULL) {
+  id <- uuid::UUIDgenerate()
+  dbExecute(con, "
+    INSERT INTO refiner_runs (id, anchor_type, anchor_intent, anchor_seed_ids,
+                               source_type, source_notebook_id, mode, weights)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+  ", list(id, anchor_type,
+          anchor_intent %||% NA_character_,
+          anchor_seed_ids %||% NA_character_,
+          source_type,
+          source_notebook_id %||% NA_character_,
+          mode,
+          weights %||% NA_character_))
+  id
+}
+
+#' Update a refiner run status
+#' @param con DuckDB connection
+#' @param run_id Run ID
+#' @param status New status
+#' @param total_candidates Total candidates (optional)
+#' @param scored_count Scored count (optional)
+update_refiner_run <- function(con, run_id, status = NULL,
+                                total_candidates = NULL, scored_count = NULL) {
+  updates <- c()
+  params <- list()
+
+  if (!is.null(status)) {
+    updates <- c(updates, "status = ?")
+    params <- c(params, list(status))
+  }
+  if (!is.null(total_candidates)) {
+    updates <- c(updates, "total_candidates = ?")
+    params <- c(params, list(as.integer(total_candidates)))
+  }
+  if (!is.null(scored_count)) {
+    updates <- c(updates, "scored_count = ?")
+    params <- c(params, list(as.integer(scored_count)))
+  }
+
+  if (!is.null(status) && status %in% c("completed", "failed", "cancelled")) {
+    updates <- c(updates, "completed_at = CURRENT_TIMESTAMP")
+  }
+
+  if (length(updates) == 0) return(invisible(NULL))
+
+  sql <- paste0("UPDATE refiner_runs SET ", paste(updates, collapse = ", "), " WHERE id = ?")
+  params <- c(params, list(run_id))
+  dbExecute(con, sql, params)
+  invisible(NULL)
+}
+
+#' Save refiner results (bulk insert)
+#' @param con DuckDB connection
+#' @param run_id Refiner run ID
+#' @param results_df Data frame with scored candidates
+#' @return Number of rows inserted
+save_refiner_results <- function(con, run_id, results_df) {
+  if (is.null(results_df) || nrow(results_df) == 0) return(invisible(0L))
+
+  ids <- vapply(seq_len(nrow(results_df)), function(i) uuid::UUIDgenerate(), character(1))
+
+  insert_df <- data.frame(
+    id = ids,
+    run_id = run_id,
+    paper_id = as.character(results_df$paper_id),
+    title = as.character(results_df$title %||% NA_character_),
+    authors = as.character(results_df$authors %||% NA_character_),
+    abstract = as.character(results_df$abstract %||% NA_character_),
+    year = as.integer(results_df$year %||% NA_integer_),
+    venue = as.character(results_df$venue %||% NA_character_),
+    doi = as.character(results_df$doi %||% NA_character_),
+    cited_by_count = as.integer(results_df$cited_by_count %||% 0L),
+    fwci = as.numeric(results_df$fwci %||% NA_real_),
+    seed_connectivity = as.numeric(results_df$seed_connectivity %||% 0),
+    bridge_score = as.numeric(results_df$bridge_score %||% 0),
+    citation_velocity = as.numeric(results_df$citation_velocity %||% 0),
+    ubiquity_penalty = as.numeric(results_df$ubiquity_penalty %||% 0),
+    utility_score = as.numeric(results_df$utility_score %||% 0),
+    embedding_similarity = NA_real_,
+    llm_utility_score = NA_real_,
+    llm_rationale = NA_character_,
+    user_action = "pending",
+    stringsAsFactors = FALSE
+  )
+
+  dbWriteTable(con, "refiner_results", insert_df, append = TRUE)
+  invisible(nrow(insert_df))
+}
+
+#' Get refiner results for a run
+#' @param con DuckDB connection
+#' @param run_id Refiner run ID
+#' @return Data frame ordered by utility_score DESC
+get_refiner_results <- function(con, run_id) {
+  dbGetQuery(con, "
+    SELECT * FROM refiner_results
+    WHERE run_id = ?
+    ORDER BY utility_score DESC
+  ", list(run_id))
+}
+
+#' Update user action on a refiner result
+#' @param con DuckDB connection
+#' @param result_id Result row ID
+#' @param action "accepted", "rejected", or "pending"
+update_refiner_result_action <- function(con, result_id, action) {
+  dbExecute(con, "
+    UPDATE refiner_results SET user_action = ? WHERE id = ?
+  ", list(action, result_id))
+  invisible(TRUE)
+}
+
+#' Get the latest refiner run
+#' @param con DuckDB connection
+#' @return Single-row data frame or NULL
+get_latest_refiner_run <- function(con) {
+  result <- dbGetQuery(con, "
+    SELECT * FROM refiner_runs
+    ORDER BY created_at DESC
+    LIMIT 1
+  ")
+  if (nrow(result) == 0) return(NULL)
+  result
 }

--- a/R/db.R
+++ b/R/db.R
@@ -2096,7 +2096,7 @@ save_refiner_results <- function(con, run_id, results_df) {
     citation_velocity = as.numeric(results_df$citation_velocity %||% 0),
     ubiquity_penalty = as.numeric(results_df$ubiquity_penalty %||% 0),
     utility_score = as.numeric(results_df$utility_score %||% 0),
-    embedding_similarity = NA_real_,
+    embedding_similarity = as.numeric(results_df$embedding_similarity %||% NA_real_),
     llm_utility_score = NA_real_,
     llm_rationale = NA_character_,
     user_action = "pending",

--- a/R/mod_keyword_filter.R
+++ b/R/mod_keyword_filter.R
@@ -26,22 +26,28 @@ mod_keyword_filter_server <- function(id, papers_data, remaining_count = reactiv
     # Reactively store keyword states: "neutral", "include", "exclude"
     keyword_states <- reactiveValues()
 
-    # Aggregate keywords from papers_data
+    # Aggregate keywords from papers_data (top-30 + any user-acted keywords)
     all_keywords <- reactive({
       papers <- papers_data()
       if (nrow(papers) == 0) return(data.frame(keyword = character(), count = integer()))
 
-      # Parse keywords from each paper
+      # Parse keywords from each paper, normalize to lowercase
       keyword_list <- lapply(seq_len(nrow(papers)), function(i) {
         kw <- papers$keywords[i]
         if (is.na(kw) || is.null(kw) || nchar(kw) == 0) return(character())
         tryCatch({
-          jsonlite::fromJSON(kw)
+          tolower(jsonlite::fromJSON(kw))
         }, error = function(e) character())
       })
 
       all_kw <- unlist(keyword_list)
-      if (length(all_kw) == 0) return(data.frame(keyword = character(), count = integer()))
+      if (length(all_kw) == 0) {
+        # Even with no paper keywords, promoted keywords should still appear
+        all_states <- reactiveValuesToList(keyword_states)
+        acted <- names(all_states)[vapply(all_states, function(s) s != "neutral", logical(1))]
+        if (length(acted) == 0) return(data.frame(keyword = character(), count = integer()))
+        return(data.frame(keyword = acted, count = rep(0L, length(acted)), stringsAsFactors = FALSE))
+      }
 
       # Count and sort
       kw_table <- table(all_kw)
@@ -52,8 +58,29 @@ mod_keyword_filter_server <- function(id, papers_data, remaining_count = reactiv
       )
       kw_df <- kw_df[order(-kw_df$count), ]
 
-      # Limit to top 30
-      head(kw_df, 30)
+      # Top 30 by frequency
+      top_30 <- head(kw_df, 30)
+
+      # Append any user-acted keywords not already in top-30 (#151)
+      all_states <- reactiveValuesToList(keyword_states)
+      acted_keywords <- names(all_states)[vapply(all_states, function(s) s != "neutral", logical(1))]
+      promoted <- setdiff(acted_keywords, top_30$keyword)
+
+      if (length(promoted) > 0) {
+        promoted_counts <- vapply(promoted, function(k) {
+          s <- kw_table[k]
+          if (is.na(s)) 0L else as.integer(s)
+        }, integer(1))
+        promoted_df <- data.frame(
+          keyword = promoted,
+          count = promoted_counts,
+          stringsAsFactors = FALSE
+        )
+        promoted_df <- promoted_df[order(-promoted_df$count), ]
+        top_30 <- rbind(top_30, promoted_df)
+      }
+
+      top_30
     })
 
     # Initialize keyword states for new keywords only (preserve existing include/exclude)
@@ -178,21 +205,14 @@ mod_keyword_filter_server <- function(id, papers_data, remaining_count = reactiv
       })
     })
 
-    # Filter summary
+    # Filter summary — count ALL keyword states, not just top-30
     output$filter_summary <- renderUI({
-      # Count active filters
-      keywords <- all_keywords()
-      if (nrow(keywords) == 0) return(NULL)
+      all_states <- reactiveValuesToList(keyword_states)
+      if (length(all_states) == 0) return(NULL)
 
-      include_count <- sum(sapply(keywords$keyword, function(kw) {
-        state <- keyword_states[[kw]] %||% "neutral"
-        state == "include"
-      }))
-
-      exclude_count <- sum(sapply(keywords$keyword, function(kw) {
-        state <- keyword_states[[kw]] %||% "neutral"
-        state == "exclude"
-      }))
+      state_values <- unlist(all_states)
+      include_count <- sum(state_values == "include")
+      exclude_count <- sum(state_values == "exclude")
 
       if (include_count == 0 && exclude_count == 0) return(NULL)
 
@@ -214,17 +234,12 @@ mod_keyword_filter_server <- function(id, papers_data, remaining_count = reactiv
       )
     })
 
-    # Clear filters link
+    # Clear filters link — check ALL keyword states
     output$clear_link <- renderUI({
-      # Show only if any filter is active
-      keywords <- all_keywords()
-      if (nrow(keywords) == 0) return(NULL)
+      all_states <- reactiveValuesToList(keyword_states)
+      if (length(all_states) == 0) return(NULL)
 
-      has_active <- any(sapply(keywords$keyword, function(kw) {
-        state <- keyword_states[[kw]] %||% "neutral"
-        state != "neutral"
-      }))
-
+      has_active <- any(vapply(all_states, function(s) s != "neutral", logical(1)))
       if (!has_active) return(NULL)
 
       div(
@@ -233,34 +248,23 @@ mod_keyword_filter_server <- function(id, papers_data, remaining_count = reactiv
       )
     })
 
-    # Clear filters handler
+    # Clear filters handler — reset ALL keyword states including promoted
     observeEvent(input$clear_filters, {
-      keywords <- all_keywords()
-      for (kw in keywords$keyword) {
+      all_states <- reactiveValuesToList(keyword_states)
+      for (kw in names(all_states)) {
         keyword_states[[kw]] <- "neutral"
       }
     })
 
-    # Filtered papers reactive (the key output)
+    # Filtered papers reactive — uses ALL keyword states (including promoted)
     filtered_papers <- reactive({
       papers <- papers_data()
       if (nrow(papers) == 0) return(papers)
 
-      keywords <- all_keywords()
-      if (nrow(keywords) == 0) return(papers)
-
-      # Collect included and excluded keywords
-      include_set <- character()
-      exclude_set <- character()
-
-      for (kw in keywords$keyword) {
-        state <- keyword_states[[kw]] %||% "neutral"
-        if (state == "include") {
-          include_set <- c(include_set, kw)
-        } else if (state == "exclude") {
-          exclude_set <- c(exclude_set, kw)
-        }
-      }
+      # Collect include/exclude from ALL keyword states, not just all_keywords()
+      all_states <- reactiveValuesToList(keyword_states)
+      include_set <- names(all_states)[vapply(all_states, function(s) s == "include", logical(1))]
+      exclude_set <- names(all_states)[vapply(all_states, function(s) s == "exclude", logical(1))]
 
       # If no filters active, return all papers
       if (length(include_set) == 0 && length(exclude_set) == 0) {
@@ -273,12 +277,12 @@ mod_keyword_filter_server <- function(id, papers_data, remaining_count = reactiv
       for (i in seq_len(nrow(papers))) {
         paper_kw_json <- papers$keywords[i]
 
-        # Parse paper keywords
+        # Parse paper keywords, normalize to lowercase for matching
         paper_keywords <- if (is.na(paper_kw_json) || is.null(paper_kw_json) || nchar(paper_kw_json) == 0) {
           character()
         } else {
           tryCatch({
-            jsonlite::fromJSON(paper_kw_json)
+            tolower(jsonlite::fromJSON(paper_kw_json))
           }, error = function(e) character())
         }
 
@@ -286,14 +290,14 @@ mod_keyword_filter_server <- function(id, papers_data, remaining_count = reactiv
         include_pass <- if (length(include_set) > 0) {
           any(paper_keywords %in% include_set)
         } else {
-          TRUE  # No include filter, passes by default
+          TRUE
         }
 
         # Check exclude filter (must NOT have any excluded keyword)
         exclude_pass <- if (length(exclude_set) > 0) {
           !any(paper_keywords %in% exclude_set)
         } else {
-          TRUE  # No exclude filter, passes by default
+          TRUE
         }
 
         # Both filters must pass (AND logic)
@@ -303,7 +307,15 @@ mod_keyword_filter_server <- function(id, papers_data, remaining_count = reactiv
       papers[keep_indices, ]
     })
 
-    # Return filtered papers reactive
-    return(reactive(filtered_papers()))
+    # Return list with filtered papers + state accessors (like mod_journal_filter pattern)
+    return(list(
+      filtered_papers = reactive(filtered_papers()),
+      set_keyword_state = function(keyword, state) {
+        keyword_states[[keyword]] <- state
+      },
+      get_keyword_state = function(keyword) {
+        keyword_states[[keyword]] %||% "neutral"
+      }
+    ))
   })
 }

--- a/R/mod_keyword_filter.R
+++ b/R/mod_keyword_filter.R
@@ -311,9 +311,11 @@ mod_keyword_filter_server <- function(id, papers_data, remaining_count = reactiv
     return(list(
       filtered_papers = reactive(filtered_papers()),
       set_keyword_state = function(keyword, state) {
+        keyword <- tolower(keyword)
         keyword_states[[keyword]] <- state
       },
       get_keyword_state = function(keyword) {
+        keyword <- tolower(keyword)
         keyword_states[[keyword]] %||% "neutral"
       }
     ))

--- a/R/mod_research_refiner.R
+++ b/R/mod_research_refiner.R
@@ -27,9 +27,9 @@ mod_research_refiner_ui <- function(id) {
           class = "card-body",
           radioButtons(ns("anchor_type"), "Anchor Type",
                        choices = c("Seed Papers" = "seeds",
-                                   "From Notebook" = "notebook_anchor",
                                    "Research Intent" = "intent",
-                                   "Both" = "both"),
+                                   "Seeds + Intent" = "both",
+                                   "From Notebook" = "notebook_anchor"),
                        selected = "seeds", inline = TRUE),
           conditionalPanel(
             condition = sprintf("input['%s'] === 'seeds' || input['%s'] === 'both'",
@@ -66,7 +66,7 @@ mod_research_refiner_ui <- function(id) {
             textAreaInput(ns("anchor_intent"),
                           "Research Intent",
                           placeholder = "Describe what you're looking for, e.g., 'How do transformers improve clinical NLP outcomes compared to traditional methods?'",
-                          rows = 3)
+                          rows = 3, width = "100%")
           )
         )
       ),

--- a/R/mod_research_refiner.R
+++ b/R/mod_research_refiner.R
@@ -493,13 +493,23 @@ mod_research_refiner_server <- function(id, con_r, config_r,
             incProgress(0.45, detail = "Scoring from embedded notebook...")
             store <- tryCatch(
               get_ragnar_store(ragnar_path, or_key, embed_model),
-              error = function(e) NULL
+              error = function(e) {
+                message("[refiner] Failed to open ragnar store: ", e$message)
+                NULL
+              }
             )
             if (!is.null(store)) {
+              # Build UUID -> OpenAlex paper_id mapping from abstracts table
+              id_map <- dbGetQuery(con, "
+                SELECT id, paper_id FROM abstracts WHERE notebook_id = ?
+              ", list(source_nb_id))
+              uuid_to_pid <- setNames(id_map$paper_id, id_map$id)
+
               sim_scores <- tryCatch(
-                score_from_ragnar_store(store, semantic_query, candidates$paper_id),
+                score_from_ragnar_store(store, semantic_query, candidates$paper_id,
+                                         uuid_to_paper_id = uuid_to_pid),
                 error = function(e) {
-                  message("Ragnar scoring failed: ", e$message)
+                  message("[refiner] Ragnar scoring failed: ", e$message)
                   NULL
                 },
                 finally = tryCatch(DBI::dbDisconnect(store@con, shutdown = TRUE), error = function(e) NULL)

--- a/R/mod_research_refiner.R
+++ b/R/mod_research_refiner.R
@@ -631,6 +631,10 @@ mod_research_refiner_server <- function(id, con_r, config_r,
                          icon = icon("times"), class = "btn-sm btn-outline-danger")
           )
         ),
+        if (nrow(results) > 100) div(
+          class = "card-body py-1 px-3 text-muted small border-bottom",
+          paste0("Showing top 100 of ", nrow(results), " papers")
+        ),
         div(
           class = "card-body p-0",
           style = "max-height: 600px; overflow-y: auto;",
@@ -789,13 +793,13 @@ mod_research_refiner_server <- function(id, con_r, config_r,
         return()
       }
 
-      for (idx in to_accept) {
-        dbExecute(con, "
-          UPDATE refiner_results SET user_action = 'accepted'
-          WHERE run_id = ? AND paper_id = ?
-        ", list(run_id, results$paper_id[[idx]]))
-        results$user_action[[idx]] <- "accepted"
-      }
+      paper_ids <- results$paper_id[to_accept]
+      placeholders <- paste(rep("?", length(paper_ids)), collapse = ", ")
+      dbExecute(con, paste0(
+        "UPDATE refiner_results SET user_action = 'accepted' ",
+        "WHERE run_id = ? AND paper_id IN (", placeholders, ")"
+      ), c(list(run_id), as.list(paper_ids)))
+      results$user_action[to_accept] <- "accepted"
 
       scored_results(results)
       showNotification(paste("Accepted top", length(to_accept), "papers"), type = "message")
@@ -820,13 +824,13 @@ mod_research_refiner_server <- function(id, con_r, config_r,
         return()
       }
 
-      for (idx in to_reject) {
-        dbExecute(con, "
-          UPDATE refiner_results SET user_action = 'rejected'
-          WHERE run_id = ? AND paper_id = ?
-        ", list(run_id, results$paper_id[[idx]]))
-        results$user_action[[idx]] <- "rejected"
-      }
+      paper_ids <- results$paper_id[to_reject]
+      placeholders <- paste(rep("?", length(paper_ids)), collapse = ", ")
+      dbExecute(con, paste0(
+        "UPDATE refiner_results SET user_action = 'rejected' ",
+        "WHERE run_id = ? AND paper_id IN (", placeholders, ")"
+      ), c(list(run_id), as.list(paper_ids)))
+      results$user_action[to_reject] <- "rejected"
 
       scored_results(results)
       showNotification(paste("Rejected", length(to_reject), "papers"), type = "message")

--- a/R/mod_research_refiner.R
+++ b/R/mod_research_refiner.R
@@ -27,6 +27,7 @@ mod_research_refiner_ui <- function(id) {
           class = "card-body",
           radioButtons(ns("anchor_type"), "Anchor Type",
                        choices = c("Seed Papers" = "seeds",
+                                   "From Notebook" = "notebook_anchor",
                                    "Research Intent" = "intent",
                                    "Both" = "both"),
                        selected = "seeds", inline = TRUE),
@@ -48,6 +49,18 @@ mod_research_refiner_ui <- function(id) {
             )
           ),
           conditionalPanel(
+            condition = sprintf("input['%s'] === 'notebook_anchor'",
+                                ns("anchor_type")),
+            div(
+              class = "mb-3",
+              uiOutput(ns("anchor_notebook_selector")),
+              sliderInput(ns("per_seed_count"), "Candidates per seed paper",
+                          min = 10, max = 100, value = 25, step = 5),
+              p(class = "text-muted small",
+                "All papers in the selected notebook become seeds. Related papers are fetched from OpenAlex and scored.")
+            )
+          ),
+          conditionalPanel(
             condition = sprintf("input['%s'] === 'intent' || input['%s'] === 'both'",
                                 ns("anchor_type"), ns("anchor_type")),
             textAreaInput(ns("anchor_intent"),
@@ -58,19 +71,21 @@ mod_research_refiner_ui <- function(id) {
         )
       ),
 
-      # Step 2: Select Candidates
-      div(
-        class = "card mb-3",
+      # Step 2: Select Candidates (hidden when anchor is notebook)
+      conditionalPanel(
+        condition = sprintf("input['%s'] !== 'notebook_anchor'", ns("anchor_type")),
         div(
-          class = "card-header",
-          strong("Step 2: Select Candidates")
-        ),
-        div(
-          class = "card-body",
-          radioButtons(ns("source_type"), "Candidate Source",
-                       choices = c("From Notebook" = "notebook",
-                                   "Fetch from Seeds" = "fetch"),
-                       selected = "notebook", inline = TRUE),
+          class = "card mb-3",
+          div(
+            class = "card-header",
+            strong("Step 2: Select Candidates")
+          ),
+          div(
+            class = "card-body",
+            radioButtons(ns("source_type"), "Candidate Source",
+                         choices = c("From Notebook" = "notebook",
+                                     "Fetch from Seeds" = "fetch"),
+                         selected = "notebook", inline = TRUE),
           conditionalPanel(
             condition = sprintf("input['%s'] === 'notebook'", ns("source_type")),
             uiOutput(ns("notebook_selector"))
@@ -82,7 +97,7 @@ mod_research_refiner_ui <- function(id) {
           ),
           uiOutput(ns("candidate_count_badge"))
         )
-      ),
+      )),
 
       # Step 3: Scoring Mode
       div(
@@ -181,6 +196,22 @@ mod_research_refiner_server <- function(id, con_r, config_r,
         c("No search notebooks" = "")
       }
       selectInput(ns("source_notebook_id"), "Search Notebook",
+                  choices = choices, width = "100%")
+    })
+
+    # Anchor notebook selector (for "From Notebook" anchor type)
+    output$anchor_notebook_selector <- renderUI({
+      con <- con_r()
+      req(con)
+      if (!is.null(notebook_refresh)) notebook_refresh()
+      nbs <- list_notebooks(con)
+      search_nbs <- nbs[nbs$type == "search", , drop = FALSE]
+      choices <- if (nrow(search_nbs) > 0) {
+        setNames(search_nbs$id, search_nbs$name)
+      } else {
+        c("No search notebooks" = "")
+      }
+      selectInput(ns("anchor_notebook_id"), "Anchor Notebook",
                   choices = choices, width = "100%")
     })
 
@@ -365,6 +396,13 @@ mod_research_refiner_server <- function(id, con_r, config_r,
         showNotification("Please enter a research intent.", type = "warning")
         return()
       }
+      if (anchor_type == "notebook_anchor") {
+        anchor_nb_id <- input$anchor_notebook_id
+        if (is.null(anchor_nb_id) || nchar(anchor_nb_id) == 0) {
+          showNotification("Please select an anchor notebook.", type = "warning")
+          return()
+        }
+      }
 
       weights <- get_current_weights()
       seed_ids <- vapply(seeds, function(p) p$paper_id, character(1))
@@ -373,7 +411,20 @@ mod_research_refiner_server <- function(id, con_r, config_r,
         # Step 1: Get candidates
         incProgress(0.1, detail = "Loading candidates...")
 
-        if (input$source_type == "notebook") {
+        if (anchor_type == "notebook_anchor") {
+          # Load all notebook papers as seeds, fetch candidates from OpenAlex
+          anchor_nb_id <- input$anchor_notebook_id
+          nb_papers <- prepare_candidates_from_notebook(con, anchor_nb_id)
+          if (nrow(nb_papers) == 0) {
+            showNotification("Anchor notebook has no papers.", type = "warning")
+            return()
+          }
+          seed_ids <- nb_papers$paper_id
+          per_seed <- input$per_seed_count %||% 25
+          incProgress(0.15, detail = paste0("Fetching candidates for ", nrow(nb_papers), " seeds..."))
+          candidates <- fetch_candidates_from_seeds(seed_ids, email, api_key,
+                                                     per_page = per_seed)
+        } else if (input$source_type == "notebook") {
           nb_id <- input$source_notebook_id
           if (is.null(nb_id) || nchar(nb_id) == 0) {
             showNotification("Please select a source notebook.", type = "warning")
@@ -408,13 +459,23 @@ mod_research_refiner_server <- function(id, con_r, config_r,
 
         # Step 4: Save to DB
         incProgress(0.8, detail = "Saving results...")
+        # Determine source metadata for DB
+        effective_source_type <- if (anchor_type == "notebook_anchor") "fetch" else input$source_type
+        effective_source_nb <- if (anchor_type == "notebook_anchor") {
+          input$anchor_notebook_id
+        } else if (input$source_type == "notebook") {
+          input$source_notebook_id
+        } else {
+          NULL
+        }
+
         run_id <- create_refiner_run(
           con,
           anchor_type = anchor_type,
-          source_type = input$source_type,
+          source_type = effective_source_type,
           anchor_intent = if (anchor_type %in% c("intent", "both")) input$anchor_intent else NULL,
           anchor_seed_ids = if (length(seed_ids) > 0) jsonlite::toJSON(seed_ids) else NULL,
-          source_notebook_id = if (input$source_type == "notebook") input$source_notebook_id else NULL,
+          source_notebook_id = effective_source_nb,
           mode = input$scoring_mode,
           weights = jsonlite::toJSON(weights, auto_unbox = TRUE)
         )

--- a/R/mod_research_refiner.R
+++ b/R/mod_research_refiner.R
@@ -190,7 +190,8 @@ mod_research_refiner_server <- function(id, con_r, config_r,
       if (nchar(seed_input) == 0) return()
 
       cfg <- config_r()
-      email <- get_setting(cfg, "openalex", "email")
+      email <- get_db_setting(con_r(), "openalex_email") %||%
+               get_setting(cfg, "openalex", "email")
       api_key <- get_setting(cfg, "openalex", "api_key")
 
       if (is.null(email) || nchar(email) == 0) {
@@ -341,7 +342,8 @@ mod_research_refiner_server <- function(id, con_r, config_r,
     observeEvent(input$run_scoring, {
       con <- con_r()
       cfg <- config_r()
-      email <- get_setting(cfg, "openalex", "email")
+      email <- get_db_setting(con, "openalex_email") %||%
+               get_setting(cfg, "openalex", "email")
       api_key <- get_setting(cfg, "openalex", "api_key")
 
       if (is.null(email) || nchar(email) == 0) {
@@ -424,7 +426,10 @@ mod_research_refiner_server <- function(id, con_r, config_r,
                            scored_count = nrow(scored))
 
         current_run_id(run_id)
-        scored_results(scored)
+        # Read back from DB to get canonical columns including user_action
+        db_results <- get_refiner_results(con, run_id)
+        db_results$rank <- seq_len(nrow(db_results))
+        scored_results(db_results)
 
         incProgress(1.0, detail = "Done!")
       })
@@ -465,7 +470,8 @@ mod_research_refiner_server <- function(id, con_r, config_r,
           strong(paste("Results:", nrow(results), "papers scored")),
           div(
             class = "d-flex gap-2",
-            actionButton(ns("accept_top_n"), "Accept Top 25",
+            actionButton(ns("accept_top_n"),
+                         if (nrow(results) <= 25) "Accept All" else "Accept Top 25",
                          icon = icon("check"), class = "btn-sm btn-outline-success"),
             actionButton(ns("reject_below_median"), "Reject Bottom Half",
                          icon = icon("times"), class = "btn-sm btn-outline-danger")
@@ -478,7 +484,8 @@ mod_research_refiner_server <- function(id, con_r, config_r,
             class = "list-group list-group-flush",
             lapply(seq_len(min(nrow(results), 100)), function(i) {
               r <- results[i, ]
-              action <- if (!is.null(r$user_action)) r$user_action else "pending"
+              action <- r$user_action %||% "pending"
+              if (is.na(action)) action <- "pending"
               bg_class <- switch(action,
                 accepted = "list-group-item-success",
                 rejected = "list-group-item-danger",
@@ -535,12 +542,20 @@ mod_research_refiner_server <- function(id, con_r, config_r,
                          paste0("Score: ", round(r$utility_score, 3))),
                     div(
                       class = "btn-group btn-group-sm",
-                      actionButton(ns(paste0("accept_", i)), NULL,
-                                   icon = icon("check"),
-                                   class = if (action == "accepted") "btn-success" else "btn-outline-success"),
-                      actionButton(ns(paste0("reject_", i)), NULL,
-                                   icon = icon("times"),
-                                   class = if (action == "rejected") "btn-danger" else "btn-outline-danger")
+                      tags$button(
+                        id = ns(paste0("accept_", i)),
+                        type = "button",
+                        class = paste("btn btn-sm action-button",
+                          if (action == "accepted") "btn-success" else "btn-outline-success"),
+                        icon("check")
+                      ),
+                      tags$button(
+                        id = ns(paste0("reject_", i)),
+                        type = "button",
+                        class = paste("btn btn-sm action-button",
+                          if (action == "rejected") "btn-danger" else "btn-outline-danger"),
+                        icon("times")
+                      )
                     )
                   )
                 )
@@ -552,49 +567,50 @@ mod_research_refiner_server <- function(id, con_r, config_r,
     })
 
     # --- Accept/reject individual papers ---
-    observe({
-      results <- scored_results()
-      if (is.null(results) || nrow(results) == 0) return()
+    # Pre-create handlers for max 100 slots (created once, not reactively)
+    lapply(seq_len(100), function(i) {
+      observeEvent(input[[paste0("accept_", i)]], {
+        results <- scored_results()
+        if (is.null(results) || i > nrow(results)) return()
 
-      n <- min(nrow(results), 100)
-      lapply(seq_len(n), function(i) {
-        observeEvent(input[[paste0("accept_", i)]], {
-          con <- con_r()
-          run_id <- current_run_id()
-          results <- scored_results()
-          r <- results[i, ]
+        con <- con_r()
+        run_id <- current_run_id()
+        current_action <- results$user_action[[i]] %||% "pending"
+        if (is.na(current_action)) current_action <- "pending"
 
-          # Toggle: if already accepted, revert to pending
-          new_action <- if (!is.null(r$user_action) && r$user_action == "accepted") "pending" else "accepted"
+        # Toggle: if already accepted, revert to pending
+        new_action <- if (current_action == "accepted") "pending" else "accepted"
 
-          # Update in DB using paper_id match
-          dbExecute(con, "
-            UPDATE refiner_results SET user_action = ?
-            WHERE run_id = ? AND paper_id = ?
-          ", list(new_action, run_id, r$paper_id))
+        # Update in DB using paper_id match
+        dbExecute(con, "
+          UPDATE refiner_results SET user_action = ?
+          WHERE run_id = ? AND paper_id = ?
+        ", list(new_action, run_id, results$paper_id[[i]]))
 
-          # Update local state
-          results$user_action[i] <- new_action
-          scored_results(results)
-        }, ignoreInit = TRUE)
+        # Update local state
+        results$user_action[[i]] <- new_action
+        scored_results(results)
+      }, ignoreInit = TRUE)
 
-        observeEvent(input[[paste0("reject_", i)]], {
-          con <- con_r()
-          run_id <- current_run_id()
-          results <- scored_results()
-          r <- results[i, ]
+      observeEvent(input[[paste0("reject_", i)]], {
+        results <- scored_results()
+        if (is.null(results) || i > nrow(results)) return()
 
-          new_action <- if (!is.null(r$user_action) && r$user_action == "rejected") "pending" else "rejected"
+        con <- con_r()
+        run_id <- current_run_id()
+        current_action <- results$user_action[[i]] %||% "pending"
+        if (is.na(current_action)) current_action <- "pending"
 
-          dbExecute(con, "
-            UPDATE refiner_results SET user_action = ?
-            WHERE run_id = ? AND paper_id = ?
-          ", list(new_action, run_id, r$paper_id))
+        new_action <- if (current_action == "rejected") "pending" else "rejected"
 
-          results$user_action[i] <- new_action
-          scored_results(results)
-        }, ignoreInit = TRUE)
-      })
+        dbExecute(con, "
+          UPDATE refiner_results SET user_action = ?
+          WHERE run_id = ? AND paper_id = ?
+        ", list(new_action, run_id, results$paper_id[[i]]))
+
+        results$user_action[[i]] <- new_action
+        scored_results(results)
+      }, ignoreInit = TRUE)
     })
 
     # --- Batch accept top N ---
@@ -604,22 +620,25 @@ mod_research_refiner_server <- function(id, con_r, config_r,
       results <- scored_results()
       req(results, run_id)
 
-      n <- min(25, nrow(results))
-      top_ids <- results$paper_id[1:n]
+      # Only accept non-rejected papers, walking down the ranked list
+      eligible <- which(results$user_action != "rejected")
+      to_accept <- head(eligible, 25)
 
-      # Update DB
-      for (pid in top_ids) {
+      if (length(to_accept) == 0) {
+        showNotification("No eligible papers to accept (all rejected).", type = "warning")
+        return()
+      }
+
+      for (idx in to_accept) {
         dbExecute(con, "
           UPDATE refiner_results SET user_action = 'accepted'
           WHERE run_id = ? AND paper_id = ?
-        ", list(run_id, pid))
+        ", list(run_id, results$paper_id[[idx]]))
+        results$user_action[[idx]] <- "accepted"
       }
 
-      # Update local state
-      results$user_action[1:n] <- "accepted"
       scored_results(results)
-
-      showNotification(paste("Accepted top", n, "papers"), type = "message")
+      showNotification(paste("Accepted top", length(to_accept), "papers"), type = "message")
     })
 
     # --- Reject bottom half ---
@@ -632,19 +651,25 @@ mod_research_refiner_server <- function(id, con_r, config_r,
       mid <- ceiling(nrow(results) / 2)
       if (mid >= nrow(results)) return()
 
-      bottom_ids <- results$paper_id[(mid + 1):nrow(results)]
+      # Only reject non-accepted papers in the bottom half
+      bottom_indices <- (mid + 1):nrow(results)
+      to_reject <- bottom_indices[results$user_action[bottom_indices] != "accepted"]
 
-      for (pid in bottom_ids) {
+      if (length(to_reject) == 0) {
+        showNotification("No eligible papers to reject (all accepted).", type = "warning")
+        return()
+      }
+
+      for (idx in to_reject) {
         dbExecute(con, "
           UPDATE refiner_results SET user_action = 'rejected'
           WHERE run_id = ? AND paper_id = ?
-        ", list(run_id, pid))
+        ", list(run_id, results$paper_id[[idx]]))
+        results$user_action[[idx]] <- "rejected"
       }
 
-      results$user_action[(mid + 1):nrow(results)] <- "rejected"
       scored_results(results)
-
-      showNotification(paste("Rejected", length(bottom_ids), "papers"), type = "message")
+      showNotification(paste("Rejected", length(to_reject), "papers"), type = "message")
     })
 
     # --- Curation section ---

--- a/R/mod_research_refiner.R
+++ b/R/mod_research_refiner.R
@@ -305,15 +305,23 @@ mod_research_refiner_server <- function(id, con_r, config_r,
     })
 
     # --- Remove individual seeds ---
+    seed_observers <- reactiveValues()
     observe({
       seeds <- seed_papers()
+      # Destroy previous observers
+      for (nm in names(seed_observers)) {
+        seed_observers[[nm]]$destroy()
+        seed_observers[[nm]] <- NULL
+      }
+      # Create fresh observers for current seed count
       lapply(seq_along(seeds), function(i) {
-        observeEvent(input[[paste0("remove_seed_", i)]], {
+        obs <- observeEvent(input[[paste0("remove_seed_", i)]], {
           current <- seed_papers()
           if (i <= length(current)) {
             seed_papers(current[-i])
           }
         }, ignoreInit = TRUE, once = TRUE)
+        seed_observers[[paste0("obs_", i)]] <- obs
       })
     })
 
@@ -911,9 +919,10 @@ mod_research_refiner_server <- function(id, con_r, config_r,
           ", list(target, p$paper_id))
           if (nrow(existing) > 0) next
 
+          authors_vec <- jsonlite::fromJSON(p$authors)
           abstract_id <- create_abstract(
             con, target, p$paper_id, p$title,
-            p$authors, p$abstract,
+            authors_vec, p$abstract,
             p$year, p$venue, NULL,
             cited_by_count = p$cited_by_count,
             fwci = p$fwci,

--- a/R/mod_research_refiner.R
+++ b/R/mod_research_refiner.R
@@ -1,0 +1,759 @@
+#' Research Refiner Module UI
+#' @param id Module ID
+mod_research_refiner_ui <- function(id) {
+  ns <- NS(id)
+  tagList(
+    div(
+      class = "container-fluid p-3",
+      # Header
+      div(
+        class = "d-flex align-items-center gap-2 mb-3",
+        icon_funnel(class = "fa-2x text-primary"),
+        div(
+          h3("Research Refiner", class = "mb-0"),
+          p(class = "text-muted mb-0 small",
+            "Score and rank papers against your research anchor")
+        )
+      ),
+
+      # Step 1: Define Anchor
+      div(
+        class = "card mb-3",
+        div(
+          class = "card-header",
+          strong("Step 1: Define Anchor")
+        ),
+        div(
+          class = "card-body",
+          radioButtons(ns("anchor_type"), "Anchor Type",
+                       choices = c("Seed Papers" = "seeds",
+                                   "Research Intent" = "intent",
+                                   "Both" = "both"),
+                       selected = "seeds", inline = TRUE),
+          conditionalPanel(
+            condition = sprintf("input['%s'] === 'seeds' || input['%s'] === 'both'",
+                                ns("anchor_type"), ns("anchor_type")),
+            div(
+              class = "mb-3",
+              textInput(ns("seed_doi"), "Seed Paper DOI or OpenAlex ID",
+                        placeholder = "e.g., 10.1234/example or W2741809807"),
+              div(
+                class = "d-flex gap-2",
+                actionButton(ns("add_seed"), "Add Seed",
+                             icon = icon("plus"), class = "btn-sm btn-outline-primary"),
+                actionButton(ns("clear_seeds"), "Clear All",
+                             icon = icon("times"), class = "btn-sm btn-outline-secondary")
+              ),
+              uiOutput(ns("seed_list"))
+            )
+          ),
+          conditionalPanel(
+            condition = sprintf("input['%s'] === 'intent' || input['%s'] === 'both'",
+                                ns("anchor_type"), ns("anchor_type")),
+            textAreaInput(ns("anchor_intent"),
+                          "Research Intent",
+                          placeholder = "Describe what you're looking for, e.g., 'How do transformers improve clinical NLP outcomes compared to traditional methods?'",
+                          rows = 3)
+          )
+        )
+      ),
+
+      # Step 2: Select Candidates
+      div(
+        class = "card mb-3",
+        div(
+          class = "card-header",
+          strong("Step 2: Select Candidates")
+        ),
+        div(
+          class = "card-body",
+          radioButtons(ns("source_type"), "Candidate Source",
+                       choices = c("From Notebook" = "notebook",
+                                   "Fetch from Seeds" = "fetch"),
+                       selected = "notebook", inline = TRUE),
+          conditionalPanel(
+            condition = sprintf("input['%s'] === 'notebook'", ns("source_type")),
+            uiOutput(ns("notebook_selector"))
+          ),
+          conditionalPanel(
+            condition = sprintf("input['%s'] === 'fetch'", ns("source_type")),
+            p(class = "text-muted small",
+              "Will fetch citing, cited, and related papers for each seed from OpenAlex.")
+          ),
+          uiOutput(ns("candidate_count_badge"))
+        )
+      ),
+
+      # Step 3: Scoring Mode
+      div(
+        class = "card mb-3",
+        div(
+          class = "card-header",
+          strong("Step 3: Scoring Mode")
+        ),
+        div(
+          class = "card-body",
+          layout_columns(
+            col_widths = c(6, 6),
+            selectInput(ns("scoring_mode"), "Mode",
+                        choices = c("Discovery" = "discovery",
+                                    "Comprehensive" = "comprehensive",
+                                    "Emerging" = "emerging"),
+                        selected = "discovery"),
+            div(
+              class = "d-flex align-items-end h-100",
+              checkboxInput(ns("show_advanced"), "Show Advanced Weights",
+                            value = FALSE)
+            )
+          ),
+          # Mode description
+          uiOutput(ns("mode_description")),
+          # Advanced weight sliders
+          conditionalPanel(
+            condition = sprintf("input['%s'] === true", ns("show_advanced")),
+            div(
+              class = "border rounded p-3 mt-2 bg-body-secondary",
+              layout_columns(
+                col_widths = c(4, 4, 4),
+                sliderInput(ns("w1"), "Seed Connectivity",
+                            min = 0, max = 1, value = 0.25, step = 0.05),
+                sliderInput(ns("w2"), "Bridge Score",
+                            min = 0, max = 1, value = 0.30, step = 0.05),
+                sliderInput(ns("w3"), "Citation Velocity",
+                            min = 0, max = 1, value = 0.20, step = 0.05)
+              ),
+              layout_columns(
+                col_widths = c(6, 6),
+                sliderInput(ns("w4"), "FWCI",
+                            min = 0, max = 1, value = 0.15, step = 0.05),
+                sliderInput(ns("w5"), "Ubiquity Penalty",
+                            min = 0, max = 1, value = 0.30, step = 0.05)
+              )
+            )
+          )
+        )
+      ),
+
+      # Score button
+      div(
+        class = "d-grid mb-3",
+        actionButton(ns("run_scoring"), "Score Papers",
+                     icon = icon_funnel(), class = "btn-primary btn-lg")
+      ),
+
+      # Results section
+      uiOutput(ns("results_section")),
+
+      # Curation actions
+      uiOutput(ns("curation_section"))
+    )
+  )
+}
+
+#' Research Refiner Module Server
+#'
+#' @param id Module ID
+#' @param con_r Reactive DuckDB connection
+#' @param config_r Reactive config
+#' @param notebook_refresh ReactiveVal for triggering notebook list refresh
+#' @param navigate_to_notebook Callback function(notebook_id)
+mod_research_refiner_server <- function(id, con_r, config_r,
+                                         notebook_refresh = NULL,
+                                         navigate_to_notebook = NULL) {
+  moduleServer(id, function(input, output, session) {
+    ns <- session$ns
+
+    # --- Reactive state ---
+    seed_papers <- reactiveVal(list())  # List of parsed seed paper objects
+    scored_results <- reactiveVal(NULL)  # Data frame of scored candidates
+    current_run_id <- reactiveVal(NULL)
+
+    # --- Notebook selector ---
+    output$notebook_selector <- renderUI({
+      con <- con_r()
+      req(con)
+      if (!is.null(notebook_refresh)) notebook_refresh()
+      nbs <- list_notebooks(con)
+      search_nbs <- nbs[nbs$type == "search", , drop = FALSE]
+      choices <- if (nrow(search_nbs) > 0) {
+        setNames(search_nbs$id, search_nbs$name)
+      } else {
+        c("No search notebooks" = "")
+      }
+      selectInput(ns("source_notebook_id"), "Search Notebook",
+                  choices = choices, width = "100%")
+    })
+
+    # --- Add seed paper ---
+    observeEvent(input$add_seed, {
+      seed_input <- trimws(input$seed_doi)
+      if (nchar(seed_input) == 0) return()
+
+      cfg <- config_r()
+      email <- get_setting(cfg, "openalex", "email")
+      api_key <- get_setting(cfg, "openalex", "api_key")
+
+      if (is.null(email) || nchar(email) == 0) {
+        showNotification("Please set your OpenAlex email in Settings first.",
+                         type = "error")
+        return()
+      }
+
+      # Determine if input is DOI or OpenAlex ID
+      if (grepl("^W\\d+$", seed_input) || grepl("^w\\d+$", seed_input)) {
+        # OpenAlex ID
+        filter_val <- paste0("openalex_id:", toupper(seed_input))
+      } else {
+        # Treat as DOI
+        doi <- normalize_doi_bare(seed_input)
+        filter_val <- paste0("doi:", doi)
+      }
+
+      # Look up paper in OpenAlex
+      withProgress(message = "Looking up seed paper...", {
+        tryCatch({
+          req_obj <- build_openalex_request("works", email, api_key) |>
+            req_url_query(filter = filter_val)
+          resp <- req_perform(req_obj)
+          body <- resp_body_json(resp)
+
+          if (is.null(body$results) || length(body$results) == 0) {
+            showNotification("Paper not found in OpenAlex.", type = "warning")
+            return()
+          }
+
+          parsed <- parse_openalex_work(body$results[[1]])
+
+          # Check for duplicates
+          existing <- seed_papers()
+          if (parsed$paper_id %in% vapply(existing, function(p) p$paper_id, character(1))) {
+            showNotification("This paper is already added as a seed.", type = "warning")
+            return()
+          }
+
+          seed_papers(c(existing, list(parsed)))
+          updateTextInput(session, "seed_doi", value = "")
+          showNotification(paste("Added seed:", parsed$title), type = "message")
+        }, error = function(e) {
+          err <- classify_api_error(e, "OpenAlex")
+          showNotification(err$message, type = "error")
+        })
+      })
+    })
+
+    # --- Clear seeds ---
+    observeEvent(input$clear_seeds, {
+      seed_papers(list())
+    })
+
+    # --- Render seed list ---
+    output$seed_list <- renderUI({
+      seeds <- seed_papers()
+      if (length(seeds) == 0) return(NULL)
+      div(
+        class = "mt-2",
+        lapply(seq_along(seeds), function(i) {
+          p <- seeds[[i]]
+          div(
+            class = "d-flex align-items-center justify-content-between border rounded p-2 mb-1",
+            div(
+              class = "text-truncate me-2",
+              strong(class = "small", p$title),
+              span(class = "text-muted small ms-1",
+                   paste0("(", p$year, ", ", p$cited_by_count, " citations)"))
+            ),
+            actionButton(ns(paste0("remove_seed_", i)), NULL,
+                         icon = icon("times"),
+                         class = "btn-sm btn-link text-muted p-0")
+          )
+        })
+      )
+    })
+
+    # --- Remove individual seeds ---
+    observe({
+      seeds <- seed_papers()
+      lapply(seq_along(seeds), function(i) {
+        observeEvent(input[[paste0("remove_seed_", i)]], {
+          current <- seed_papers()
+          if (i <= length(current)) {
+            seed_papers(current[-i])
+          }
+        }, ignoreInit = TRUE, once = TRUE)
+      })
+    })
+
+    # --- Mode description ---
+    output$mode_description <- renderUI({
+      mode <- input$scoring_mode
+      desc <- switch(mode,
+        discovery = "Find what you're missing — favors bridge papers, novel connections, and emerging work.",
+        comprehensive = "Build the full picture — broad coverage with high-impact papers.",
+        emerging = "What's new and rising — recent papers with high citation velocity."
+      )
+      p(class = "text-muted small fst-italic", desc)
+    })
+
+    # --- Update sliders when mode changes ---
+    observeEvent(input$scoring_mode, {
+      if (!isTRUE(input$show_advanced)) return()
+      weights <- get_preset_weights(input$scoring_mode)
+      updateSliderInput(session, "w1", value = weights$w1)
+      updateSliderInput(session, "w2", value = weights$w2)
+      updateSliderInput(session, "w3", value = weights$w3)
+      updateSliderInput(session, "w4", value = weights$w4)
+      updateSliderInput(session, "w5", value = weights$w5)
+    })
+
+    # --- Candidate count badge ---
+    output$candidate_count_badge <- renderUI({
+      if (input$source_type == "notebook") {
+        nb_id <- input$source_notebook_id
+        if (is.null(nb_id) || nchar(nb_id) == 0) return(NULL)
+        con <- con_r()
+        count <- dbGetQuery(con, "SELECT COUNT(*) as n FROM abstracts WHERE notebook_id = ?",
+                            list(nb_id))
+        span(class = "badge bg-secondary mt-2", paste0(count$n, " papers available"))
+      } else {
+        seeds <- seed_papers()
+        if (length(seeds) == 0) return(NULL)
+        span(class = "badge bg-info mt-2",
+             paste0(length(seeds), " seed(s) — papers will be fetched from OpenAlex"))
+      }
+    })
+
+    # --- Get current weights ---
+    get_current_weights <- reactive({
+      if (isTRUE(input$show_advanced)) {
+        list(
+          w1 = input$w1 %||% 0.25,
+          w2 = input$w2 %||% 0.30,
+          w3 = input$w3 %||% 0.20,
+          w4 = input$w4 %||% 0.15,
+          w5 = input$w5 %||% 0.30
+        )
+      } else {
+        get_preset_weights(input$scoring_mode %||% "discovery")
+      }
+    })
+
+    # --- Run scoring ---
+    observeEvent(input$run_scoring, {
+      con <- con_r()
+      cfg <- config_r()
+      email <- get_setting(cfg, "openalex", "email")
+      api_key <- get_setting(cfg, "openalex", "api_key")
+
+      if (is.null(email) || nchar(email) == 0) {
+        showNotification("Please set your OpenAlex email in Settings first.",
+                         type = "error")
+        return()
+      }
+
+      seeds <- seed_papers()
+      anchor_type <- input$anchor_type
+
+      # Validate anchor
+      if (anchor_type %in% c("seeds", "both") && length(seeds) == 0) {
+        showNotification("Please add at least one seed paper.", type = "warning")
+        return()
+      }
+      if (anchor_type %in% c("intent", "both") &&
+          (is.null(input$anchor_intent) || nchar(trimws(input$anchor_intent)) == 0)) {
+        showNotification("Please enter a research intent.", type = "warning")
+        return()
+      }
+
+      weights <- get_current_weights()
+      seed_ids <- vapply(seeds, function(p) p$paper_id, character(1))
+
+      withProgress(message = "Scoring papers...", {
+        # Step 1: Get candidates
+        incProgress(0.1, detail = "Loading candidates...")
+
+        if (input$source_type == "notebook") {
+          nb_id <- input$source_notebook_id
+          if (is.null(nb_id) || nchar(nb_id) == 0) {
+            showNotification("Please select a source notebook.", type = "warning")
+            return()
+          }
+          candidates <- prepare_candidates_from_notebook(con, nb_id, exclude_ids = seed_ids)
+        } else {
+          candidates <- fetch_candidates_from_seeds(seed_ids, email, api_key,
+                                                     per_page = 50)
+        }
+
+        if (nrow(candidates) == 0) {
+          showNotification("No candidates found to score.", type = "warning")
+          return()
+        }
+
+        # Step 2: Compute seed connectivity (if we have seeds)
+        incProgress(0.3, detail = "Computing connectivity...")
+        if (length(seed_ids) > 0) {
+          anchor_data <- tryCatch(
+            fetch_anchor_refs(seed_ids, email, api_key),
+            error = function(e) {
+              list(anchor_refs = list(), anchor_ids = seed_ids, anchor_papers = list())
+            }
+          )
+          candidates$seed_connectivity <- compute_pool_connectivity(candidates, anchor_data)
+        }
+
+        # Step 3: Score candidates
+        incProgress(0.5, detail = "Scoring candidates...")
+        scored <- score_candidate_pool(candidates, weights)
+
+        # Step 4: Save to DB
+        incProgress(0.8, detail = "Saving results...")
+        run_id <- create_refiner_run(
+          con,
+          anchor_type = anchor_type,
+          source_type = input$source_type,
+          anchor_intent = if (anchor_type %in% c("intent", "both")) input$anchor_intent else NULL,
+          anchor_seed_ids = if (length(seed_ids) > 0) jsonlite::toJSON(seed_ids) else NULL,
+          source_notebook_id = if (input$source_type == "notebook") input$source_notebook_id else NULL,
+          mode = input$scoring_mode,
+          weights = jsonlite::toJSON(weights, auto_unbox = TRUE)
+        )
+
+        save_refiner_results(con, run_id, scored)
+        update_refiner_run(con, run_id,
+                           status = "completed",
+                           total_candidates = nrow(scored),
+                           scored_count = nrow(scored))
+
+        current_run_id(run_id)
+        scored_results(scored)
+
+        incProgress(1.0, detail = "Done!")
+      })
+
+      # Check for missing data and warn
+      has_connectivity <- any(!is.na(scored_results()$seed_connectivity))
+      has_fwci <- any(!is.na(scored_results()$fwci))
+
+      warnings <- character(0)
+      if (!has_connectivity) {
+        warnings <- c(warnings, "Seed connectivity data unavailable — scoring based on citation metrics only.")
+      }
+      if (!has_fwci) {
+        warnings <- c(warnings, "FWCI data unavailable for all papers — excluded from scoring.")
+      }
+      if (length(warnings) > 0) {
+        showNotification(
+          paste(warnings, collapse = " "),
+          type = "warning", duration = 8
+        )
+      }
+
+      showNotification(
+        paste("Scored", nrow(scored_results()), "candidates"),
+        type = "message"
+      )
+    })
+
+    # --- Results section ---
+    output$results_section <- renderUI({
+      results <- scored_results()
+      if (is.null(results) || nrow(results) == 0) return(NULL)
+
+      div(
+        class = "card mb-3",
+        div(
+          class = "card-header d-flex justify-content-between align-items-center",
+          strong(paste("Results:", nrow(results), "papers scored")),
+          div(
+            class = "d-flex gap-2",
+            actionButton(ns("accept_top_n"), "Accept Top 25",
+                         icon = icon("check"), class = "btn-sm btn-outline-success"),
+            actionButton(ns("reject_below_median"), "Reject Bottom Half",
+                         icon = icon("times"), class = "btn-sm btn-outline-danger")
+          )
+        ),
+        div(
+          class = "card-body p-0",
+          style = "max-height: 600px; overflow-y: auto;",
+          div(
+            class = "list-group list-group-flush",
+            lapply(seq_len(min(nrow(results), 100)), function(i) {
+              r <- results[i, ]
+              action <- if (!is.null(r$user_action)) r$user_action else "pending"
+              bg_class <- switch(action,
+                accepted = "list-group-item-success",
+                rejected = "list-group-item-danger",
+                ""
+              )
+
+              # Parse authors for display
+              authors_display <- tryCatch({
+                au <- jsonlite::fromJSON(r$authors)
+                if (length(au) > 3) paste(c(au[1:3], "et al."), collapse = ", ")
+                else paste(au, collapse = ", ")
+              }, error = function(e) r$authors %||% "")
+
+              div(
+                class = paste("list-group-item", bg_class),
+                div(
+                  class = "d-flex justify-content-between align-items-start",
+                  div(
+                    class = "flex-grow-1 me-3",
+                    div(
+                      class = "d-flex align-items-center gap-2",
+                      span(class = "badge bg-primary", paste0("#", r$rank)),
+                      strong(r$title)
+                    ),
+                    div(
+                      class = "small text-muted mt-1",
+                      paste0(
+                        authors_display,
+                        if (!is.na(r$year)) paste0(" | ", r$year) else "",
+                        if (!is.na(r$venue) && nchar(r$venue) > 0) paste0(" | ", r$venue) else ""
+                      )
+                    ),
+                    div(
+                      class = "small mt-1",
+                      span(class = "badge bg-secondary me-1",
+                           paste0(r$cited_by_count, " cit")),
+                      if (!is.na(r$citation_velocity)) {
+                        span(class = "badge bg-info me-1",
+                             paste0(round(r$citation_velocity, 1), " cit/yr"))
+                      },
+                      if (!is.na(r$fwci)) {
+                        span(class = "badge bg-warning me-1",
+                             paste0("FWCI ", round(r$fwci, 2)))
+                      },
+                      if (!is.na(r$seed_connectivity) && r$seed_connectivity > 0) {
+                        span(class = "badge bg-success me-1",
+                             paste0(r$seed_connectivity, " seed links"))
+                      }
+                    )
+                  ),
+                  div(
+                    class = "d-flex flex-column gap-1 align-items-end",
+                    span(class = "badge bg-primary fs-6",
+                         paste0("Score: ", round(r$utility_score, 3))),
+                    div(
+                      class = "btn-group btn-group-sm",
+                      actionButton(ns(paste0("accept_", i)), NULL,
+                                   icon = icon("check"),
+                                   class = if (action == "accepted") "btn-success" else "btn-outline-success"),
+                      actionButton(ns(paste0("reject_", i)), NULL,
+                                   icon = icon("times"),
+                                   class = if (action == "rejected") "btn-danger" else "btn-outline-danger")
+                    )
+                  )
+                )
+              )
+            })
+          )
+        )
+      )
+    })
+
+    # --- Accept/reject individual papers ---
+    observe({
+      results <- scored_results()
+      if (is.null(results) || nrow(results) == 0) return()
+
+      n <- min(nrow(results), 100)
+      lapply(seq_len(n), function(i) {
+        observeEvent(input[[paste0("accept_", i)]], {
+          con <- con_r()
+          run_id <- current_run_id()
+          results <- scored_results()
+          r <- results[i, ]
+
+          # Toggle: if already accepted, revert to pending
+          new_action <- if (!is.null(r$user_action) && r$user_action == "accepted") "pending" else "accepted"
+
+          # Update in DB using paper_id match
+          dbExecute(con, "
+            UPDATE refiner_results SET user_action = ?
+            WHERE run_id = ? AND paper_id = ?
+          ", list(new_action, run_id, r$paper_id))
+
+          # Update local state
+          results$user_action[i] <- new_action
+          scored_results(results)
+        }, ignoreInit = TRUE)
+
+        observeEvent(input[[paste0("reject_", i)]], {
+          con <- con_r()
+          run_id <- current_run_id()
+          results <- scored_results()
+          r <- results[i, ]
+
+          new_action <- if (!is.null(r$user_action) && r$user_action == "rejected") "pending" else "rejected"
+
+          dbExecute(con, "
+            UPDATE refiner_results SET user_action = ?
+            WHERE run_id = ? AND paper_id = ?
+          ", list(new_action, run_id, r$paper_id))
+
+          results$user_action[i] <- new_action
+          scored_results(results)
+        }, ignoreInit = TRUE)
+      })
+    })
+
+    # --- Batch accept top N ---
+    observeEvent(input$accept_top_n, {
+      con <- con_r()
+      run_id <- current_run_id()
+      results <- scored_results()
+      req(results, run_id)
+
+      n <- min(25, nrow(results))
+      top_ids <- results$paper_id[1:n]
+
+      # Update DB
+      for (pid in top_ids) {
+        dbExecute(con, "
+          UPDATE refiner_results SET user_action = 'accepted'
+          WHERE run_id = ? AND paper_id = ?
+        ", list(run_id, pid))
+      }
+
+      # Update local state
+      results$user_action[1:n] <- "accepted"
+      scored_results(results)
+
+      showNotification(paste("Accepted top", n, "papers"), type = "message")
+    })
+
+    # --- Reject bottom half ---
+    observeEvent(input$reject_below_median, {
+      con <- con_r()
+      run_id <- current_run_id()
+      results <- scored_results()
+      req(results, run_id)
+
+      mid <- ceiling(nrow(results) / 2)
+      if (mid >= nrow(results)) return()
+
+      bottom_ids <- results$paper_id[(mid + 1):nrow(results)]
+
+      for (pid in bottom_ids) {
+        dbExecute(con, "
+          UPDATE refiner_results SET user_action = 'rejected'
+          WHERE run_id = ? AND paper_id = ?
+        ", list(run_id, pid))
+      }
+
+      results$user_action[(mid + 1):nrow(results)] <- "rejected"
+      scored_results(results)
+
+      showNotification(paste("Rejected", length(bottom_ids), "papers"), type = "message")
+    })
+
+    # --- Curation section ---
+    output$curation_section <- renderUI({
+      results <- scored_results()
+      if (is.null(results)) return(NULL)
+
+      accepted_count <- sum(results$user_action == "accepted", na.rm = TRUE)
+      if (accepted_count == 0) return(NULL)
+
+      con <- con_r()
+      nbs <- list_notebooks(con)
+
+      div(
+        class = "card mb-3",
+        div(
+          class = "card-header",
+          strong(paste("Export:", accepted_count, "accepted papers"))
+        ),
+        div(
+          class = "card-body",
+          layout_columns(
+            col_widths = c(6, 3, 3),
+            selectInput(ns("target_notebook"), "Import into Notebook",
+                        choices = c("Create New Notebook" = "__new__",
+                                    setNames(nbs$id, nbs$name))),
+            conditionalPanel(
+              condition = sprintf("input['%s'] === '__new__'", ns("target_notebook")),
+              textInput(ns("new_nb_name"), "New Notebook Name",
+                        placeholder = "e.g., Refined Results")
+            ),
+            div(
+              class = "d-flex align-items-end h-100",
+              actionButton(ns("import_accepted"), "Import Papers",
+                           icon = icon_file_import(),
+                           class = "btn-success")
+            )
+          )
+        )
+      )
+    })
+
+    # --- Import accepted papers ---
+    observeEvent(input$import_accepted, {
+      con <- con_r()
+      results <- scored_results()
+      req(results)
+
+      accepted <- results[results$user_action == "accepted", , drop = FALSE]
+      if (nrow(accepted) == 0) {
+        showNotification("No accepted papers to import.", type = "warning")
+        return()
+      }
+
+      # Determine target notebook
+      target <- input$target_notebook
+      if (target == "__new__") {
+        nb_name <- trimws(input$new_nb_name %||% "")
+        if (nchar(nb_name) == 0) {
+          showNotification("Please enter a name for the new notebook.", type = "warning")
+          return()
+        }
+        target <- create_notebook(con, nb_name, "search")
+      }
+
+      # Import papers
+      imported <- 0
+      withProgress(message = "Importing papers...", {
+        for (j in seq_len(nrow(accepted))) {
+          p <- accepted[j, ]
+
+          # Check for duplicate
+          existing <- dbGetQuery(con, "
+            SELECT id FROM abstracts WHERE notebook_id = ? AND paper_id = ?
+          ", list(target, p$paper_id))
+          if (nrow(existing) > 0) next
+
+          abstract_id <- create_abstract(
+            con, target, p$paper_id, p$title,
+            p$authors, p$abstract,
+            p$year, p$venue, NULL,
+            cited_by_count = p$cited_by_count,
+            fwci = p$fwci,
+            doi = p$doi
+          )
+
+          # Create chunk for abstract text
+          if (!is.na(p$abstract) && nchar(p$abstract) > 0) {
+            create_chunk(con, abstract_id, "abstract", 0, p$abstract)
+          }
+
+          imported <- imported + 1
+          incProgress(j / nrow(accepted))
+        }
+      })
+
+      if (!is.null(notebook_refresh)) {
+        notebook_refresh(notebook_refresh() + 1)
+      }
+
+      showNotification(
+        paste("Imported", imported, "papers into notebook"),
+        type = "message"
+      )
+
+      # Navigate to the target notebook
+      if (!is.null(navigate_to_notebook)) {
+        navigate_to_notebook(target)
+      }
+    })
+  })
+}

--- a/R/mod_research_refiner.R
+++ b/R/mod_research_refiner.R
@@ -138,10 +138,12 @@ mod_research_refiner_ui <- function(id) {
                             min = 0, max = 1, value = 0.20, step = 0.05)
               ),
               layout_columns(
-                col_widths = c(6, 6),
+                col_widths = c(4, 4, 4),
                 sliderInput(ns("w4"), "FWCI",
                             min = 0, max = 1, value = 0.15, step = 0.05),
                 sliderInput(ns("w5"), "Ubiquity Penalty",
+                            min = 0, max = 1, value = 0.30, step = 0.05),
+                sliderInput(ns("w6"), "Semantic Relevance",
                             min = 0, max = 1, value = 0.30, step = 0.05)
               )
             )
@@ -362,7 +364,8 @@ mod_research_refiner_server <- function(id, con_r, config_r,
           w2 = input$w2 %||% 0.30,
           w3 = input$w3 %||% 0.20,
           w4 = input$w4 %||% 0.15,
-          w5 = input$w5 %||% 0.30
+          w5 = input$w5 %||% 0.30,
+          w6 = input$w6 %||% 0.30
         )
       } else {
         get_preset_weights(input$scoring_mode %||% "discovery")
@@ -453,8 +456,82 @@ mod_research_refiner_server <- function(id, con_r, config_r,
           candidates$seed_connectivity <- compute_pool_connectivity(candidates, anchor_data)
         }
 
+        # Step 2.5: Semantic scoring (Tier 2)
+        incProgress(0.4, detail = "Computing semantic relevance...")
+
+        # Build query from intent and/or seed abstracts
+        seed_abstracts <- if (anchor_type == "notebook_anchor") {
+          # For notebook anchor, use anchor notebook paper abstracts
+          nb_papers <- dbGetQuery(con, "
+            SELECT abstract FROM abstracts WHERE notebook_id = ? AND abstract IS NOT NULL
+          ", list(input$anchor_notebook_id))
+          nb_papers$abstract
+        } else if (length(seeds) > 0) {
+          vapply(seeds, function(p) p$abstract %||% NA_character_, character(1))
+        } else {
+          NULL
+        }
+        intent_text <- if (anchor_type %in% c("intent", "both")) input$anchor_intent else NULL
+        semantic_query <- build_semantic_query(intent_text, seed_abstracts)
+
+        if (!is.null(semantic_query)) {
+          # Determine which path: existing ragnar store or temp store
+          source_nb_id <- if (anchor_type == "notebook_anchor") NULL
+                          else if (input$source_type == "notebook") input$source_notebook_id
+                          else NULL
+
+          ragnar_path <- if (!is.null(source_nb_id)) get_notebook_ragnar_path(source_nb_id) else NULL
+          has_ragnar <- !is.null(ragnar_path) && file.exists(ragnar_path)
+
+          or_key <- get_db_setting(con, "openrouter_api_key") %||%
+                    get_setting(cfg, "openrouter", "api_key")
+          embed_model <- get_db_setting(con, "embedding_model") %||%
+                         "openai/text-embedding-3-small"
+
+          if (has_ragnar && !is.null(or_key) && nchar(or_key) > 0) {
+            # Path A: use existing ragnar store
+            incProgress(0.45, detail = "Scoring from embedded notebook...")
+            store <- tryCatch(
+              get_ragnar_store(ragnar_path, or_key, embed_model),
+              error = function(e) NULL
+            )
+            if (!is.null(store)) {
+              sim_scores <- tryCatch(
+                score_from_ragnar_store(store, semantic_query, candidates$paper_id),
+                error = function(e) {
+                  message("Ragnar scoring failed: ", e$message)
+                  NULL
+                },
+                finally = tryCatch(DBI::dbDisconnect(store@con, shutdown = TRUE), error = function(e) NULL)
+              )
+              if (!is.null(sim_scores)) {
+                candidates$embedding_similarity <- unname(sim_scores[candidates$paper_id])
+              }
+            }
+          } else if (!is.null(or_key) && nchar(or_key) > 0) {
+            # Path B: create temp ragnar store for fetched candidates
+            incProgress(0.45, detail = "Embedding candidates...")
+            sim_scores <- tryCatch(
+              score_with_temp_ragnar(candidates, semantic_query, or_key, embed_model,
+                                      progress_callback = function(detail) {
+                                        incProgress(0, detail = detail)
+                                      }),
+              error = function(e) {
+                showNotification(
+                  paste("Semantic scoring failed:", e$message),
+                  type = "warning", duration = 5
+                )
+                NULL
+              }
+            )
+            if (!is.null(sim_scores)) {
+              candidates$embedding_similarity <- unname(sim_scores[candidates$paper_id])
+            }
+          }
+        }
+
         # Step 3: Score candidates
-        incProgress(0.5, detail = "Scoring candidates...")
+        incProgress(0.6, detail = "Scoring candidates...")
         scored <- score_candidate_pool(candidates, weights)
 
         # Step 4: Save to DB
@@ -498,6 +575,8 @@ mod_research_refiner_server <- function(id, con_r, config_r,
       # Check for missing data and warn
       has_connectivity <- any(!is.na(scored_results()$seed_connectivity))
       has_fwci <- any(!is.na(scored_results()$fwci))
+      has_embedding <- "embedding_similarity" %in% names(scored_results()) &&
+                       any(!is.na(scored_results()$embedding_similarity))
 
       warnings <- character(0)
       if (!has_connectivity) {
@@ -505,6 +584,9 @@ mod_research_refiner_server <- function(id, con_r, config_r,
       }
       if (!has_fwci) {
         warnings <- c(warnings, "FWCI data unavailable for all papers — excluded from scoring.")
+      }
+      if (!has_embedding) {
+        warnings <- c(warnings, "Semantic relevance unavailable — embed the notebook or add a research intent for better ranking.")
       }
       if (length(warnings) > 0) {
         showNotification(
@@ -594,6 +676,12 @@ mod_research_refiner_server <- function(id, con_r, config_r,
                       if (!is.na(r$seed_connectivity) && r$seed_connectivity > 0) {
                         span(class = "badge bg-success me-1",
                              paste0(r$seed_connectivity, " seed links"))
+                      },
+                      if ("embedding_similarity" %in% names(r) &&
+                          !is.na(r$embedding_similarity) && r$embedding_similarity > 0) {
+                        span(class = "badge bg-purple me-1",
+                             style = "background-color: #6f42c1;",
+                             paste0(round(r$embedding_similarity * 100), "% relevant"))
                       }
                     )
                   ),

--- a/R/mod_research_refiner.R
+++ b/R/mod_research_refiner.R
@@ -337,6 +337,7 @@ mod_research_refiner_server <- function(id, con_r, config_r,
       updateSliderInput(session, "w3", value = weights$w3)
       updateSliderInput(session, "w4", value = weights$w4)
       updateSliderInput(session, "w5", value = weights$w5)
+      updateSliderInput(session, "w6", value = weights$w6)
     })
 
     # --- Candidate count badge ---

--- a/R/mod_research_refiner.R
+++ b/R/mod_research_refiner.R
@@ -419,40 +419,36 @@ mod_research_refiner_server <- function(id, con_r, config_r,
       weights <- get_current_weights()
       seed_ids <- vapply(seeds, function(p) p$paper_id, character(1))
 
-      withProgress(message = "Scoring papers...", {
-        # Step 1: Get candidates
-        incProgress(0.1, detail = "Loading candidates...")
-
-        if (anchor_type == "notebook_anchor") {
-          # Load all notebook papers as seeds, fetch candidates from OpenAlex
-          anchor_nb_id <- input$anchor_notebook_id
-          nb_papers <- prepare_candidates_from_notebook(con, anchor_nb_id)
-          if (nrow(nb_papers) == 0) {
-            showNotification("Anchor notebook has no papers.", type = "warning")
-            return()
-          }
-          seed_ids <- nb_papers$paper_id
-          per_seed <- input$per_seed_count %||% 25
-          incProgress(0.15, detail = paste0("Fetching candidates for ", nrow(nb_papers), " seeds..."))
-          candidates <- fetch_candidates_from_seeds(seed_ids, email, api_key,
-                                                     per_page = per_seed)
-        } else if (input$source_type == "notebook") {
-          nb_id <- input$source_notebook_id
-          if (is.null(nb_id) || nchar(nb_id) == 0) {
-            showNotification("Please select a source notebook.", type = "warning")
-            return()
-          }
-          candidates <- prepare_candidates_from_notebook(con, nb_id, exclude_ids = seed_ids)
-        } else {
-          candidates <- fetch_candidates_from_seeds(seed_ids, email, api_key,
-                                                     per_page = 50)
-        }
-
-        if (nrow(candidates) == 0) {
-          showNotification("No candidates found to score.", type = "warning")
+      # Step 1: Get candidates (outside withProgress to avoid frozen progress bar on early return)
+      if (anchor_type == "notebook_anchor") {
+        anchor_nb_id <- input$anchor_notebook_id
+        nb_papers <- prepare_candidates_from_notebook(con, anchor_nb_id)
+        if (nrow(nb_papers) == 0) {
+          showNotification("Anchor notebook has no papers.", type = "warning")
           return()
         }
+        seed_ids <- nb_papers$paper_id
+        per_seed <- input$per_seed_count %||% 25
+        candidates <- fetch_candidates_from_seeds(seed_ids, email, api_key,
+                                                   per_page = per_seed)
+      } else if (input$source_type == "notebook") {
+        nb_id <- input$source_notebook_id
+        if (is.null(nb_id) || nchar(nb_id) == 0) {
+          showNotification("Please select a source notebook.", type = "warning")
+          return()
+        }
+        candidates <- prepare_candidates_from_notebook(con, nb_id, exclude_ids = seed_ids)
+      } else {
+        candidates <- fetch_candidates_from_seeds(seed_ids, email, api_key,
+                                                   per_page = 50)
+      }
 
+      if (nrow(candidates) == 0) {
+        showNotification("No candidates found to score.", type = "warning")
+        return()
+      }
+
+      withProgress(message = "Scoring papers...", {
         # Step 2: Compute seed connectivity (if we have seeds)
         incProgress(0.3, detail = "Computing connectivity...")
         if (length(seed_ids) > 0) {
@@ -793,7 +789,7 @@ mod_research_refiner_server <- function(id, con_r, config_r,
       req(results, run_id)
 
       # Only accept non-rejected papers, walking down the ranked list
-      eligible <- which(results$user_action != "rejected")
+      eligible <- which(is.na(results$user_action) | results$user_action != "rejected")
       to_accept <- head(eligible, 25)
 
       if (length(to_accept) == 0) {
@@ -825,7 +821,7 @@ mod_research_refiner_server <- function(id, con_r, config_r,
 
       # Only reject non-accepted papers in the bottom half
       bottom_indices <- (mid + 1):nrow(results)
-      to_reject <- bottom_indices[results$user_action[bottom_indices] != "accepted"]
+      to_reject <- bottom_indices[is.na(results$user_action[bottom_indices]) | results$user_action[bottom_indices] != "accepted"]
 
       if (length(to_reject) == 0) {
         showNotification("No eligible papers to reject (all accepted).", type = "warning")
@@ -919,7 +915,18 @@ mod_research_refiner_server <- function(id, con_r, config_r,
           ", list(target, p$paper_id))
           if (nrow(existing) > 0) next
 
-          authors_vec <- jsonlite::fromJSON(p$authors)
+          authors_vec <- tryCatch(
+            jsonlite::fromJSON(p$authors),
+            error = function(e) {
+              showNotification(
+                paste0("Skipping paper with malformed author data: ", p$title),
+                type = "warning"
+              )
+              NULL
+            }
+          )
+          if (is.null(authors_vec)) next
+
           abstract_id <- create_abstract(
             con, target, p$paper_id, p$title,
             authors_vec, p$abstract,

--- a/R/mod_search_notebook.R
+++ b/R/mod_search_notebook.R
@@ -1825,13 +1825,13 @@ mod_search_notebook_server <- function(id, con, notebook_id, config, notebook_re
                 ""
               )
 
-              # Escape keyword for safe JS embedding
-              k_escaped <- htmltools::htmlEscape(k_lower, attribute = TRUE)
+              # Escape keyword for safe JS embedding (JSON produces a quoted string)
+              k_js <- jsonlite::toJSON(k_lower, auto_unbox = TRUE)
 
               onclick_js <- sprintf(
-                "Shiny.setInputValue('%s', {keyword: '%s', nonce: Math.random()})",
+                "Shiny.setInputValue('%s', {keyword: %s, nonce: Math.random()})",
                 ns("abstract_kw_click"),
-                k_escaped
+                k_js
               )
 
               tags$span(

--- a/R/mod_search_notebook.R
+++ b/R/mod_search_notebook.R
@@ -817,37 +817,39 @@ mod_search_notebook_server <- function(id, con, notebook_id, config, notebook_re
     observe({
       result <- reindex_task$result()
 
-      poller <- reindex_poller()
-      if (!is.null(poller)) poller$destroy()
-      reindex_poller(NULL)
+      isolate({
+        poller <- reindex_poller()
+        if (!is.null(poller)) poller$destroy()
+        reindex_poller(NULL)
 
-      clear_interrupt_flag(current_interrupt_flag())
-      clear_progress_file(current_progress_file())
-      current_interrupt_flag(NULL)
-      current_progress_file(NULL)
+        clear_interrupt_flag(current_interrupt_flag())
+        clear_progress_file(current_progress_file())
+        current_interrupt_flag(NULL)
+        current_progress_file(NULL)
 
-      removeModal()
+        removeModal()
 
-      if (isTRUE(result$partial)) {
-        # Cancelled — delete partial store
-        tryCatch(delete_notebook_store(notebook_id()), error = function(e) NULL)
-        rag_ready(FALSE)
-        store_healthy(FALSE)
-        showNotification("Re-indexing cancelled. Partial index removed.", type = "warning", duration = 5)
-      } else if (isTRUE(result$success)) {
-        rag_ready(TRUE)
-        store_healthy(TRUE)
-        tryCatch({
-          abstract_ids <- DBI::dbGetQuery(con(), "SELECT id FROM abstracts WHERE notebook_id = ?", list(notebook_id()))$id
-          mark_as_ragnar_indexed(con(), abstract_ids, source_type = "abstract")
-        }, error = function(e) message("[ragnar] Sentinel update failed: ", e$message))
-        paper_refresh(paper_refresh() + 1)
-        showNotification(paste("Re-indexed", result$count, "items successfully."), type = "message", duration = 5)
-      } else {
-        rag_ready(FALSE)
-        store_healthy(FALSE)
-        showNotification(paste("Re-indexing failed:", result$error), type = "error", duration = NULL)
-      }
+        if (isTRUE(result$partial)) {
+          # Cancelled — delete partial store
+          tryCatch(delete_notebook_store(notebook_id()), error = function(e) NULL)
+          rag_ready(FALSE)
+          store_healthy(FALSE)
+          showNotification("Re-indexing cancelled. Partial index removed.", type = "warning", duration = 5)
+        } else if (isTRUE(result$success)) {
+          rag_ready(TRUE)
+          store_healthy(TRUE)
+          tryCatch({
+            abstract_ids <- DBI::dbGetQuery(con(), "SELECT id FROM abstracts WHERE notebook_id = ?", list(notebook_id()))$id
+            mark_as_ragnar_indexed(con(), abstract_ids, source_type = "abstract")
+          }, error = function(e) message("[ragnar] Sentinel update failed: ", e$message))
+          paper_refresh(paper_refresh() + 1)
+          showNotification(paste("Re-indexed", result$count, "items successfully."), type = "message", duration = 5)
+        } else {
+          rag_ready(FALSE)
+          store_healthy(FALSE)
+          showNotification(paste("Re-indexing failed:", result$error), type = "error", duration = NULL)
+        }
+      })
     })
 
     # Phase 22: Render send button (disabled when rag_available is FALSE)

--- a/R/mod_search_notebook.R
+++ b/R/mod_search_notebook.R
@@ -943,8 +943,24 @@ mod_search_notebook_server <- function(id, con, notebook_id, config, notebook_re
       remaining
     })
 
-    # Keyword filter module - returns filtered papers reactive
-    keyword_filtered_papers <- mod_keyword_filter_server("keyword_filter", papers_data, remaining_count)
+    # Keyword filter module - returns list with filtered_papers + state accessors
+    keyword_filter_result <- mod_keyword_filter_server("keyword_filter", papers_data, remaining_count)
+    keyword_filtered_papers <- keyword_filter_result$filtered_papers
+
+    # Delegated click handler for per-abstract keyword toggles (#151)
+    observeEvent(input$abstract_kw_click, {
+      kw <- input$abstract_kw_click$keyword
+      if (is.null(kw) || !nzchar(kw)) return()
+
+      current_state <- keyword_filter_result$get_keyword_state(kw)
+      new_state <- switch(current_state,
+        "neutral" = "include",
+        "include" = "exclude",
+        "exclude" = "neutral",
+        "include"
+      )
+      keyword_filter_result$set_keyword_state(kw, new_state)
+    }, ignoreInit = TRUE)
 
     # Phase 55: Type filter - client-side filtering between keyword and journal
     type_filtered_papers <- reactive({
@@ -1772,7 +1788,7 @@ mod_search_notebook_server <- function(id, con, notebook_id, config, notebook_re
         paste(authors, collapse = ", ")
       }
 
-      # Parse keywords
+      # Parse keywords — interactive badges with ban/keep toggle
       keywords_ui <- NULL
       if (!is.null(paper$keywords) && !is.na(paper$keywords) && nchar(paper$keywords) > 0) {
         keywords <- tryCatch({
@@ -1784,7 +1800,46 @@ mod_search_notebook_server <- function(id, con, notebook_id, config, notebook_re
             class = "mt-2",
             tags$small(class = "text-muted", "Keywords: "),
             lapply(keywords, function(k) {
-              span(class = "badge bg-secondary me-1", k)
+              # Look up current state from global keyword filter
+              k_lower <- tolower(k)
+              state <- keyword_filter_result$get_keyword_state(k_lower)
+
+              badge_class <- switch(state,
+                "include" = "badge bg-success me-1",
+                "exclude" = "badge bg-danger me-1",
+                "badge bg-secondary me-1"
+              )
+
+              badge_icon <- switch(state,
+                "include" = icon_add(class = "me-1"),
+                "exclude" = icon_minus(class = "me-1"),
+                NULL
+              )
+
+              badge_title <- switch(state,
+                "neutral" = paste0("Click to include '", k, "' in filter"),
+                "include" = paste0("Click to exclude '", k, "'"),
+                "exclude" = paste0("Click to clear '", k, "' filter"),
+                ""
+              )
+
+              # Escape keyword for safe JS embedding
+              k_escaped <- htmltools::htmlEscape(k_lower, attribute = TRUE)
+
+              onclick_js <- sprintf(
+                "Shiny.setInputValue('%s', {keyword: '%s', nonce: Math.random()})",
+                ns("abstract_kw_click"),
+                k_escaped
+              )
+
+              tags$span(
+                class = badge_class,
+                style = "cursor: pointer;",
+                onclick = onclick_js,
+                title = badge_title,
+                badge_icon,
+                k
+              )
             })
           )
         }

--- a/R/research_refiner.R
+++ b/R/research_refiner.R
@@ -24,7 +24,10 @@ fetch_anchor_refs <- function(seed_ids, email, api_key = NULL) {
     req <- build_openalex_request("works", email, api_key) |>
       req_url_query(filter = paste0("openalex_id:", sid))
 
-    resp <- tryCatch(req_perform(req), error = function(e) NULL)
+    resp <- tryCatch(req_perform(req), error = function(e) {
+      warning("Failed to fetch anchor refs for ", sid, ": ", e$message)
+      NULL
+    })
     if (is.null(resp)) next
 
     body <- resp_body_json(resp)
@@ -67,8 +70,9 @@ prepare_candidates_from_notebook <- function(con, notebook_id, exclude_ids = cha
     papers <- papers[!papers$paper_id %in% exclude_ids, , drop = FALSE]
   }
 
-  # Ensure numeric types
+  # Ensure numeric types (replace both NULL columns and NA values)
   papers$cited_by_count <- as.integer(papers$cited_by_count %||% 0L)
+  papers$cited_by_count[is.na(papers$cited_by_count)] <- 0L
   papers$year <- as.integer(papers$year)
   papers$fwci <- as.numeric(papers$fwci)
 
@@ -123,7 +127,7 @@ fetch_candidates_from_seeds <- function(seed_ids, email, api_key = NULL,
                                          per_page = 50,
                                          progress_callback = NULL) {
   all_papers <- list()
-  seen_ids <- character(0)
+  seen_ids <- new.env(hash = TRUE, parent = emptyenv())
 
   for (i in seq_along(seed_ids)) {
     sid <- seed_ids[i]
@@ -134,21 +138,30 @@ fetch_candidates_from_seeds <- function(seed_ids, email, api_key = NULL,
     # Fetch citing, cited, and related
     citing <- tryCatch(
       get_citing_papers(sid, email, api_key, per_page = per_page),
-      error = function(e) list()
+      error = function(e) {
+        warning("Failed to fetch citing papers for ", sid, ": ", e$message)
+        list()
+      }
     )
     cited <- tryCatch(
       get_cited_papers(sid, email, api_key, per_page = per_page),
-      error = function(e) list()
+      error = function(e) {
+        warning("Failed to fetch cited papers for ", sid, ": ", e$message)
+        list()
+      }
     )
     related <- tryCatch(
       get_related_papers(sid, email, api_key, per_page = per_page),
-      error = function(e) list()
+      error = function(e) {
+        warning("Failed to fetch related papers for ", sid, ": ", e$message)
+        list()
+      }
     )
 
     for (paper in c(citing, cited, related)) {
-      if (paper$paper_id %in% seen_ids) next
+      if (exists(paper$paper_id, envir = seen_ids, inherits = FALSE)) next
       if (paper$paper_id %in% seed_ids) next  # Exclude seeds from candidates
-      seen_ids <- c(seen_ids, paper$paper_id)
+      assign(paper$paper_id, TRUE, envir = seen_ids)
       all_papers <- c(all_papers, list(paper))
     }
   }
@@ -175,9 +188,15 @@ fetch_candidates_from_seeds <- function(seed_ids, email, api_key = NULL,
     year = vapply(all_papers, function(p) as.integer(p$year %||% NA_integer_), integer(1)),
     venue = vapply(all_papers, function(p) p$venue %||% NA_character_, character(1)),
     doi = vapply(all_papers, function(p) p$doi %||% NA_character_, character(1)),
-    cited_by_count = vapply(all_papers, function(p) as.integer(p$cited_by_count %||% 0L), integer(1)),
+    cited_by_count = vapply(all_papers, function(p) {
+      v <- p$cited_by_count %||% 0L
+      if (is.na(v)) 0L else as.integer(v)
+    }, integer(1)),
     fwci = vapply(all_papers, function(p) as.numeric(p$fwci %||% NA_real_), numeric(1)),
-    referenced_works_count = vapply(all_papers, function(p) as.integer(p$referenced_works_count %||% 0L), integer(1)),
+    referenced_works_count = vapply(all_papers, function(p) {
+      v <- p$referenced_works_count %||% 0L
+      if (is.na(v)) 0L else as.integer(v)
+    }, integer(1)),
     seed_connectivity = NA_real_,
     bridge_score = NA_real_,
     stringsAsFactors = FALSE
@@ -312,23 +331,19 @@ score_with_temp_ragnar <- function(candidates, query_text, openrouter_api_key,
 
   store <- get_ragnar_store(temp_path, openrouter_api_key, embed_model)
 
-  # Ingest candidate abstracts
-  for (i in seq_len(nrow(scoreable))) {
-    if (!is.null(progress_callback)) {
-      progress_callback(paste0("Embedding abstract ", i, "/", nrow(scoreable), "..."))
-    }
-    row <- scoreable[i, ]
-    origin <- paste0("abstract:", row$paper_id)
-    chunks <- data.frame(
-      content = row$abstract,
-      page_number = NA_integer_,
-      chunk_index = 0,
-      context = "",
-      origin = origin,
-      stringsAsFactors = FALSE
-    )
-    insert_chunks_to_ragnar(store, chunks, row$paper_id, "abstract")
+  # Ingest candidate abstracts (batched for efficiency)
+  if (!is.null(progress_callback)) {
+    progress_callback(paste0("Embedding ", nrow(scoreable), " abstracts..."))
   }
+  chunks <- data.frame(
+    content = scoreable$abstract,
+    page_number = NA_integer_,
+    chunk_index = 0L,
+    context = "",
+    origin = paste0("abstract:", scoreable$paper_id),
+    stringsAsFactors = FALSE
+  )
+  insert_chunks_to_ragnar(store, chunks, "batch", "abstract")
 
   # Build index for BM25
   build_ragnar_index(store)

--- a/R/research_refiner.R
+++ b/R/research_refiner.R
@@ -218,8 +218,13 @@ build_semantic_query <- function(intent = NULL, seed_abstracts = NULL) {
 #' @param store RagnarStore object (must have embed function attached)
 #' @param query_text Search query for semantic scoring
 #' @param candidate_paper_ids Character vector of paper IDs to score
+#' @param uuid_to_paper_id Named character vector mapping abstract UUIDs to
+#'   OpenAlex paper IDs. Required because ragnar origins use internal UUIDs
+#'   while candidates use OpenAlex IDs. If NULL, assumes origin IDs match
+#'   candidate IDs directly.
 #' @return Named numeric vector: paper_id -> similarity score [0, 1]
-score_from_ragnar_store <- function(store, query_text, candidate_paper_ids) {
+score_from_ragnar_store <- function(store, query_text, candidate_paper_ids,
+                                     uuid_to_paper_id = NULL) {
   # Retrieve all candidates (generous top_k to get full coverage)
   results <- tryCatch(
     ragnar::ragnar_retrieve(store, query_text, top_k = length(candidate_paper_ids) * 2),
@@ -233,13 +238,20 @@ score_from_ragnar_store <- function(store, query_text, candidate_paper_ids) {
     return(setNames(rep(NA_real_, length(candidate_paper_ids)), candidate_paper_ids))
   }
 
-  # Extract paper_id from origin field (format: "abstract:{paper_id}|...")
-  results$paper_id <- vapply(results$origin, function(o) {
-    # Strip "abstract:" prefix and any pipe-delimited metadata
+
+  # Extract UUID from origin field (format: "abstract:{uuid}|...")
+  results$origin_uuid <- vapply(results$origin, function(o) {
     id <- sub("^abstract:", "", o)
     id <- sub("\\|.*$", "", id)
     id
   }, character(1))
+
+  # Map UUIDs to OpenAlex paper IDs if mapping provided
+  if (!is.null(uuid_to_paper_id)) {
+    results$paper_id <- uuid_to_paper_id[results$origin_uuid]
+  } else {
+    results$paper_id <- results$origin_uuid
+  }
 
   # Convert cosine_distance to similarity (lower distance = higher similarity)
   if ("cosine_distance" %in% names(results)) {

--- a/R/research_refiner.R
+++ b/R/research_refiner.R
@@ -1,0 +1,185 @@
+# Research Refiner Business Logic
+#
+# Candidate fetching, anchor reference resolution, and scoring pipeline.
+# Designed for use inside mirai workers — no DuckDB or Shiny dependencies.
+
+#' Fetch anchor paper's reference lists from OpenAlex
+#'
+#' For each seed paper, retrieves the paper's metadata and its referenced_works
+#' list. Returns structures needed to compute seed_connectivity.
+#'
+#' @param seed_ids Character vector of OpenAlex work IDs (W-prefixed)
+#' @param email Email for OpenAlex polite pool
+#' @param api_key Optional OpenAlex API key
+#' @return List with:
+#'   - anchor_refs: list of character vectors (referenced_works per seed)
+#'   - anchor_ids: character vector of seed paper IDs
+#'   - anchor_papers: list of parsed work objects
+fetch_anchor_refs <- function(seed_ids, email, api_key = NULL) {
+  anchor_refs <- list()
+  anchor_papers <- list()
+
+  for (sid in seed_ids) {
+    # Fetch the seed paper to get its referenced_works
+    req <- build_openalex_request("works", email, api_key) |>
+      req_url_query(filter = paste0("openalex_id:", sid))
+
+    resp <- tryCatch(req_perform(req), error = function(e) NULL)
+    if (is.null(resp)) next
+
+    body <- resp_body_json(resp)
+    if (is.null(body$results) || length(body$results) == 0) next
+
+    parsed <- parse_openalex_work(body$results[[1]])
+    anchor_papers <- c(anchor_papers, list(parsed))
+    anchor_refs <- c(anchor_refs, list(parsed$referenced_works))
+  }
+
+  list(
+    anchor_refs = anchor_refs,
+    anchor_ids = seed_ids,
+    anchor_papers = anchor_papers
+  )
+}
+
+#' Prepare candidates from a notebook's abstracts
+#'
+#' Reads papers from the abstracts table and returns a data frame ready for
+#' scoring. Called from the main Shiny process (has DB access).
+#'
+#' @param con DuckDB connection
+#' @param notebook_id Notebook ID
+#' @param exclude_ids Optional character vector of paper IDs to exclude (e.g., seed papers)
+#' @return Data frame with columns needed by score_candidate_pool
+prepare_candidates_from_notebook <- function(con, notebook_id, exclude_ids = character(0)) {
+  papers <- dbGetQuery(con, "
+    SELECT paper_id, title, authors, abstract, year, venue, doi,
+           cited_by_count, fwci, referenced_works_count
+    FROM abstracts
+    WHERE notebook_id = ?
+  ", list(notebook_id))
+
+  if (nrow(papers) == 0) return(papers)
+
+  # Exclude seed papers from candidates
+
+  if (length(exclude_ids) > 0) {
+    papers <- papers[!papers$paper_id %in% exclude_ids, , drop = FALSE]
+  }
+
+  # Ensure numeric types
+  papers$cited_by_count <- as.integer(papers$cited_by_count %||% 0L)
+  papers$year <- as.integer(papers$year)
+  papers$fwci <- as.numeric(papers$fwci)
+
+  # Initialize optional scoring columns as NA (will be computed if data available)
+  papers$seed_connectivity <- NA_real_
+  papers$bridge_score <- NA_real_
+
+  papers
+}
+
+#' Compute seed connectivity for all candidates
+#'
+#' For each candidate, counts how many seed papers have a direct citation
+#' link. Requires anchor_refs (what seeds cite) and candidate referenced_works
+#' (what candidates cite).
+#'
+#' @param candidates Data frame of candidates (must have paper_id column)
+#' @param anchor_data List from fetch_anchor_refs()
+#' @param candidate_refs Named list: paper_id -> character vector of referenced_works
+#'   (optional; if NULL, only forward connectivity is computed)
+#' @return Numeric vector of connectivity scores (same length as candidates)
+compute_pool_connectivity <- function(candidates, anchor_data,
+                                       candidate_refs = NULL) {
+  vapply(seq_len(nrow(candidates)), function(i) {
+    pid <- candidates$paper_id[i]
+    crefs <- if (!is.null(candidate_refs)) {
+      candidate_refs[[pid]] %||% character(0)
+    } else {
+      character(0)
+    }
+    compute_seed_connectivity(
+      pid,
+      anchor_data$anchor_refs,
+      anchor_data$anchor_ids,
+      crefs
+    )
+  }, numeric(1))
+}
+
+#' Fetch candidates from seed papers via OpenAlex
+#'
+#' For each seed, fetches citing papers, cited papers, and related papers.
+#' De-duplicates across seeds. Returns a data frame ready for scoring.
+#'
+#' @param seed_ids Character vector of seed paper IDs
+#' @param email Email for OpenAlex
+#' @param api_key Optional API key
+#' @param per_page Results per page per query (default 50)
+#' @param progress_callback Optional function(message) for progress updates
+#' @return Data frame of unique candidate papers
+fetch_candidates_from_seeds <- function(seed_ids, email, api_key = NULL,
+                                         per_page = 50,
+                                         progress_callback = NULL) {
+  all_papers <- list()
+  seen_ids <- character(0)
+
+  for (i in seq_along(seed_ids)) {
+    sid <- seed_ids[i]
+    if (!is.null(progress_callback)) {
+      progress_callback(paste0("Fetching papers for seed ", i, "/", length(seed_ids)))
+    }
+
+    # Fetch citing, cited, and related
+    citing <- tryCatch(
+      get_citing_papers(sid, email, api_key, per_page = per_page),
+      error = function(e) list()
+    )
+    cited <- tryCatch(
+      get_cited_papers(sid, email, api_key, per_page = per_page),
+      error = function(e) list()
+    )
+    related <- tryCatch(
+      get_related_papers(sid, email, api_key, per_page = per_page),
+      error = function(e) list()
+    )
+
+    for (paper in c(citing, cited, related)) {
+      if (paper$paper_id %in% seen_ids) next
+      if (paper$paper_id %in% seed_ids) next  # Exclude seeds from candidates
+      seen_ids <- c(seen_ids, paper$paper_id)
+      all_papers <- c(all_papers, list(paper))
+    }
+  }
+
+  if (length(all_papers) == 0) {
+    return(data.frame(
+      paper_id = character(0), title = character(0), authors = character(0),
+      abstract = character(0), year = integer(0), venue = character(0),
+      doi = character(0), cited_by_count = integer(0), fwci = double(0),
+      referenced_works_count = integer(0), seed_connectivity = double(0),
+      bridge_score = double(0),
+      stringsAsFactors = FALSE
+    ))
+  }
+
+  # Convert list of papers to data frame
+  data.frame(
+    paper_id = vapply(all_papers, function(p) p$paper_id, character(1)),
+    title = vapply(all_papers, function(p) p$title %||% "Untitled", character(1)),
+    authors = vapply(all_papers, function(p) {
+      if (length(p$authors) > 0) jsonlite::toJSON(p$authors, auto_unbox = TRUE) else "[]"
+    }, character(1)),
+    abstract = vapply(all_papers, function(p) p$abstract %||% NA_character_, character(1)),
+    year = vapply(all_papers, function(p) as.integer(p$year %||% NA_integer_), integer(1)),
+    venue = vapply(all_papers, function(p) p$venue %||% NA_character_, character(1)),
+    doi = vapply(all_papers, function(p) p$doi %||% NA_character_, character(1)),
+    cited_by_count = vapply(all_papers, function(p) as.integer(p$cited_by_count %||% 0L), integer(1)),
+    fwci = vapply(all_papers, function(p) as.numeric(p$fwci %||% NA_real_), numeric(1)),
+    referenced_works_count = vapply(all_papers, function(p) as.integer(p$referenced_works_count %||% 0L), integer(1)),
+    seed_connectivity = NA_real_,
+    bridge_score = NA_real_,
+    stringsAsFactors = FALSE
+  )
+}

--- a/R/research_refiner.R
+++ b/R/research_refiner.R
@@ -183,3 +183,145 @@ fetch_candidates_from_seeds <- function(seed_ids, email, api_key = NULL,
     stringsAsFactors = FALSE
   )
 }
+
+# ---- Semantic Scoring (Tier 2) ----
+
+#' Build a query string for semantic scoring
+#'
+#' Constructs a search query from intent text and/or seed paper abstracts.
+#'
+#' @param intent Optional intent text
+#' @param seed_abstracts Optional character vector of seed paper abstracts
+#' @return Character string query
+build_semantic_query <- function(intent = NULL, seed_abstracts = NULL) {
+  parts <- character(0)
+  if (!is.null(intent) && nchar(trimws(intent)) > 0) {
+    parts <- c(parts, intent)
+  }
+  if (!is.null(seed_abstracts)) {
+    # Use first 3 seed abstracts (truncated) to keep query manageable
+    abstracts <- seed_abstracts[!is.na(seed_abstracts)]
+    abstracts <- head(abstracts, 3)
+    abstracts <- vapply(abstracts, function(a) substr(a, 1, 500), character(1))
+    parts <- c(parts, abstracts)
+  }
+  if (length(parts) == 0) return(NULL)
+  paste(parts, collapse = "\n\n")
+}
+
+#' Compute semantic similarity scores using an existing ragnar store
+#'
+#' Retrieves BM25+VSS scores for candidates that are already embedded in a
+#' ragnar store (e.g., from a search notebook). Maps scores back to paper_ids
+#' via the origin field (format: "abstract:{paper_id}|...").
+#'
+#' @param store RagnarStore object (must have embed function attached)
+#' @param query_text Search query for semantic scoring
+#' @param candidate_paper_ids Character vector of paper IDs to score
+#' @return Named numeric vector: paper_id -> similarity score [0, 1]
+score_from_ragnar_store <- function(store, query_text, candidate_paper_ids) {
+  # Retrieve all candidates (generous top_k to get full coverage)
+  results <- tryCatch(
+    ragnar::ragnar_retrieve(store, query_text, top_k = length(candidate_paper_ids) * 2),
+    error = function(e) {
+      message("Ragnar retrieval failed: ", e$message)
+      return(NULL)
+    }
+  )
+
+  if (is.null(results) || nrow(results) == 0) {
+    return(setNames(rep(NA_real_, length(candidate_paper_ids)), candidate_paper_ids))
+  }
+
+  # Extract paper_id from origin field (format: "abstract:{paper_id}|...")
+  results$paper_id <- vapply(results$origin, function(o) {
+    # Strip "abstract:" prefix and any pipe-delimited metadata
+    id <- sub("^abstract:", "", o)
+    id <- sub("\\|.*$", "", id)
+    id
+  }, character(1))
+
+  # Convert cosine_distance to similarity (lower distance = higher similarity)
+  if ("cosine_distance" %in% names(results)) {
+    results$similarity <- 1 - results$cosine_distance
+  } else {
+    results$similarity <- NA_real_
+  }
+
+  # Map back to candidate IDs
+  scores <- setNames(rep(NA_real_, length(candidate_paper_ids)), candidate_paper_ids)
+  for (i in seq_len(nrow(results))) {
+    pid <- results$paper_id[i]
+    if (pid %in% candidate_paper_ids && !is.na(results$similarity[i])) {
+      # Take best (highest) similarity if paper appears multiple times
+      existing <- scores[[pid]]
+      if (is.na(existing) || results$similarity[i] > existing) {
+        scores[[pid]] <- results$similarity[i]
+      }
+    }
+  }
+  scores
+}
+
+#' Compute semantic similarity using a temporary ragnar store
+#'
+#' For candidates not in any ragnar store (e.g., fetched from OpenAlex),
+#' creates a temp store, ingests candidate abstracts, embeds them, then
+#' retrieves with hybrid BM25+VSS.
+#'
+#' @param candidates Data frame with paper_id and abstract columns
+#' @param query_text Search query for semantic scoring
+#' @param openrouter_api_key API key for embedding
+#' @param embed_model Embedding model ID
+#' @param progress_callback Optional function(detail_text) for progress updates
+#' @return Named numeric vector: paper_id -> similarity score [0, 1]
+score_with_temp_ragnar <- function(candidates, query_text, openrouter_api_key,
+                                    embed_model = "openai/text-embedding-3-small",
+                                    progress_callback = NULL) {
+  # Filter to candidates with abstracts
+  has_abstract <- !is.na(candidates$abstract) & nchar(candidates$abstract) > 0
+  scoreable <- candidates[has_abstract, , drop = FALSE]
+
+  if (nrow(scoreable) == 0) {
+    return(setNames(rep(NA_real_, nrow(candidates)), candidates$paper_id))
+  }
+
+  # Create temporary ragnar store
+  temp_path <- tempfile(pattern = "refiner_", fileext = ".duckdb")
+  on.exit({
+    tryCatch({
+      DBI::dbDisconnect(store@con, shutdown = TRUE)
+      unlink(temp_path, force = TRUE)
+      unlink(paste0(temp_path, ".wal"), force = TRUE)
+    }, error = function(e) NULL)
+  }, add = TRUE)
+
+  if (!is.null(progress_callback)) progress_callback("Creating temporary store...")
+
+  store <- get_ragnar_store(temp_path, openrouter_api_key, embed_model)
+
+  # Ingest candidate abstracts
+  for (i in seq_len(nrow(scoreable))) {
+    if (!is.null(progress_callback)) {
+      progress_callback(paste0("Embedding abstract ", i, "/", nrow(scoreable), "..."))
+    }
+    row <- scoreable[i, ]
+    origin <- paste0("abstract:", row$paper_id)
+    chunks <- data.frame(
+      content = row$abstract,
+      page_number = NA_integer_,
+      chunk_index = 0,
+      context = "",
+      origin = origin,
+      stringsAsFactors = FALSE
+    )
+    insert_chunks_to_ragnar(store, chunks, row$paper_id, "abstract")
+  }
+
+  # Build index for BM25
+  build_ragnar_index(store)
+
+  # Retrieve with hybrid scoring
+  scores <- score_from_ragnar_store(store, query_text, candidates$paper_id)
+  scores
+}

--- a/R/theme_catppuccin.R
+++ b/R/theme_catppuccin.R
@@ -271,6 +271,11 @@ icon_diagram <- function(...) shiny::icon("diagram-project", ...)
 #' @return Icon tag
 icon_audit <- function(...) shiny::icon("magnifying-glass-chart", ...)
 
+#' Filter/funnel icon (research refiner)
+#' @param ... Additional arguments passed to shiny::icon()
+#' @return Icon tag
+icon_funnel <- function(...) shiny::icon("filter", ...)
+
 #' File import icon (import papers)
 #' @param ... Additional arguments passed to shiny::icon()
 #' @return Icon tag

--- a/R/utils_scoring.R
+++ b/R/utils_scoring.R
@@ -155,6 +155,7 @@ compute_utility_score <- function(seed_connectivity, bridge_score,
 #' @return Numeric vector scaled to [0, 1]
 normalize_01 <- function(x) {
   if (length(x) == 0) return(numeric(0))
+  if (all(is.na(x))) return(x)
   rng <- range(x, na.rm = TRUE)
   if (rng[1] == rng[2]) return(rep(0.5, length(x)))
   (x - rng[1]) / (rng[2] - rng[1])

--- a/R/utils_scoring.R
+++ b/R/utils_scoring.R
@@ -66,7 +66,7 @@ compute_seed_connectivity <- function(paper_id, anchor_refs, anchor_ids,
 #' Get preset weights for a scoring mode
 #'
 #' @param mode Character: "discovery", "comprehensive", or "emerging"
-#' @return Named list with w1-w5
+#' @return Named list with w1-w6
 get_preset_weights <- function(mode = "discovery") {
   switch(mode,
     discovery = list(
@@ -74,24 +74,27 @@ get_preset_weights <- function(mode = "discovery") {
       w2 = 0.30,  # bridge_score
       w3 = 0.20,  # citation_velocity
       w4 = 0.15,  # fwci
-      w5 = 0.30   # ubiquity_penalty
+      w5 = 0.30,  # ubiquity_penalty
+      w6 = 0.30   # embedding_similarity
     ),
     comprehensive = list(
       w1 = 0.30,
       w2 = 0.10,
       w3 = 0.20,
       w4 = 0.30,
-      w5 = 0.05
+      w5 = 0.05,
+      w6 = 0.25
     ),
     emerging = list(
       w1 = 0.10,
       w2 = 0.15,
       w3 = 0.40,
       w4 = 0.25,
-      w5 = 0.20
+      w5 = 0.20,
+      w6 = 0.20
     ),
     # Default to discovery
-    list(w1 = 0.25, w2 = 0.30, w3 = 0.20, w4 = 0.15, w5 = 0.30)
+    list(w1 = 0.25, w2 = 0.30, w3 = 0.20, w4 = 0.15, w5 = 0.30, w6 = 0.30)
   )
 }
 
@@ -107,18 +110,21 @@ get_preset_weights <- function(mode = "discovery") {
 #' @param citation_velocity Numeric or NA
 #' @param fwci Numeric or NA
 #' @param ubiquity_penalty Numeric or NA (this is subtracted, not added)
-#' @param weights Named list with w1-w5
+#' @param embedding_similarity Numeric or NA (Tier 2 semantic signal)
+#' @param weights Named list with w1-w6
 #' @return Numeric composite score
 compute_utility_score <- function(seed_connectivity, bridge_score,
                                    citation_velocity, fwci, ubiquity_penalty,
-                                   weights) {
+                                   weights,
+                                   embedding_similarity = NA_real_) {
   # Build components: name, value, weight, is_penalty
   components <- list(
-    list(val = seed_connectivity, w = weights$w1, penalty = FALSE),
-    list(val = bridge_score,      w = weights$w2, penalty = FALSE),
-    list(val = citation_velocity, w = weights$w3, penalty = FALSE),
-    list(val = fwci,              w = weights$w4, penalty = FALSE),
-    list(val = ubiquity_penalty,  w = weights$w5, penalty = TRUE)
+    list(val = seed_connectivity,   w = weights$w1, penalty = FALSE),
+    list(val = bridge_score,        w = weights$w2, penalty = FALSE),
+    list(val = citation_velocity,   w = weights$w3, penalty = FALSE),
+    list(val = fwci,                w = weights$w4, penalty = FALSE),
+    list(val = ubiquity_penalty,    w = weights$w5, penalty = TRUE),
+    list(val = embedding_similarity, w = weights$w6 %||% 0, penalty = FALSE)
   )
 
   # Separate available from missing
@@ -185,6 +191,7 @@ score_candidate_pool <- function(candidates, weights) {
   # Ensure optional columns exist (NA if not provided)
   if (is.null(candidates$seed_connectivity)) candidates$seed_connectivity <- NA_real_
   if (is.null(candidates$bridge_score)) candidates$bridge_score <- NA_real_
+  if (is.null(candidates$embedding_similarity)) candidates$embedding_similarity <- NA_real_
 
   # Normalize available components to 0-1
   candidates$norm_velocity <- normalize_01(candidates$citation_velocity)
@@ -217,16 +224,27 @@ score_candidate_pool <- function(candidates, weights) {
     candidates$norm_fwci <- NA_real_
   }
 
+  # Normalize embedding_similarity if available
+  if (any(!is.na(candidates$embedding_similarity))) {
+    candidates$norm_embedding <- normalize_01(
+      ifelse(is.na(candidates$embedding_similarity), NA_real_, candidates$embedding_similarity)
+    )
+  } else {
+    candidates$norm_embedding <- NA_real_
+  }
+
   # Compute composite utility score per paper
   candidates$utility_score <- mapply(
-    function(conn, bridge, vel, fwci_val, ubiq) {
-      compute_utility_score(conn, bridge, vel, fwci_val, ubiq, weights)
+    function(conn, bridge, vel, fwci_val, ubiq, embed_sim) {
+      compute_utility_score(conn, bridge, vel, fwci_val, ubiq, weights,
+                            embedding_similarity = embed_sim)
     },
     candidates$norm_connectivity,
     candidates$norm_bridge,
     candidates$norm_velocity,
     candidates$norm_fwci,
-    candidates$norm_ubiquity
+    candidates$norm_ubiquity,
+    candidates$norm_embedding
   )
 
   # Sort by utility score descending

--- a/R/utils_scoring.R
+++ b/R/utils_scoring.R
@@ -1,0 +1,240 @@
+# Scoring Utilities for Research Refiner
+#
+# Pure functions for computing paper utility scores.
+# No Shiny dependencies — reusable by any module.
+
+#' Compute citation velocity (citations per year since publication)
+#'
+#' @param cited_by_count Integer citation count
+#' @param year Integer publication year
+#' @return Numeric citations per year
+compute_citation_velocity <- function(cited_by_count, year) {
+  current_year <- as.integer(format(Sys.Date(), "%Y"))
+  age <- max(current_year - year, 1L)
+  cited_by_count / age
+}
+
+#' Compute ubiquity penalty
+#'
+#' Papers with citation counts above the pool's threshold percentile are
+#' penalized as "assumed knowledge." Returns 0-1 where 1 = maximum penalty.
+#'
+#' @param cited_by_count Integer citation count for this paper
+#' @param pool_citations Numeric vector of all citation counts in the pool
+#' @param threshold Percentile above which papers are penalized (0-1, default 0.9)
+#' @return Numeric penalty 0-1
+compute_ubiquity_penalty <- function(cited_by_count, pool_citations,
+                                      threshold = 0.9) {
+  if (length(pool_citations) == 0) return(0)
+  threshold_value <- quantile(pool_citations, probs = threshold, names = FALSE)
+  if (threshold_value == 0) return(0)
+
+  if (cited_by_count > threshold_value) {
+    pool_max <- max(pool_citations)
+    if (pool_max == threshold_value) return(1)
+    min((cited_by_count - threshold_value) / (pool_max - threshold_value), 1)
+  } else {
+    0
+  }
+}
+
+#' Compute seed connectivity
+#'
+#' Counts how many anchor (seed) papers have a direct citation link to this
+#' candidate — either the seed cites the candidate, or the candidate cites the
+#' seed.
+#'
+#' @param paper_id Character OpenAlex work ID (W-prefixed)
+#' @param anchor_refs List of character vectors — each element is the
+#'   referenced_works list for one seed paper
+#' @param anchor_ids Character vector of seed paper IDs
+#' @param candidate_refs Character vector of this candidate's referenced_works
+#' @return Integer connectivity count
+compute_seed_connectivity <- function(paper_id, anchor_refs, anchor_ids,
+                                       candidate_refs = character(0)) {
+  # How many seeds cite this candidate (candidate appears in seed's refs)
+  forward <- sum(vapply(anchor_refs, function(refs) {
+    paper_id %in% refs
+  }, logical(1)))
+
+  # How many seeds this candidate cites (seed appears in candidate's refs)
+  backward <- sum(anchor_ids %in% candidate_refs)
+
+  forward + backward
+}
+
+#' Get preset weights for a scoring mode
+#'
+#' @param mode Character: "discovery", "comprehensive", or "emerging"
+#' @return Named list with w1-w5
+get_preset_weights <- function(mode = "discovery") {
+  switch(mode,
+    discovery = list(
+      w1 = 0.25,  # seed_connectivity
+      w2 = 0.30,  # bridge_score
+      w3 = 0.20,  # citation_velocity
+      w4 = 0.15,  # fwci
+      w5 = 0.30   # ubiquity_penalty
+    ),
+    comprehensive = list(
+      w1 = 0.30,
+      w2 = 0.10,
+      w3 = 0.20,
+      w4 = 0.30,
+      w5 = 0.05
+    ),
+    emerging = list(
+      w1 = 0.10,
+      w2 = 0.15,
+      w3 = 0.40,
+      w4 = 0.25,
+      w5 = 0.20
+    ),
+    # Default to discovery
+    list(w1 = 0.25, w2 = 0.30, w3 = 0.20, w4 = 0.15, w5 = 0.30)
+  )
+}
+
+#' Compute composite utility score with weight re-normalization
+#'
+#' When a scoring component is unavailable (NA/NULL), its weight is excluded
+#' and the remaining weights are re-normalized to sum to the original total.
+#' This avoids penalizing papers that lack certain metadata (e.g., preprints
+#' without FWCI, candidates without graph data for bridge scores).
+#'
+#' @param seed_connectivity Numeric or NA
+#' @param bridge_score Numeric or NA
+#' @param citation_velocity Numeric or NA
+#' @param fwci Numeric or NA
+#' @param ubiquity_penalty Numeric or NA (this is subtracted, not added)
+#' @param weights Named list with w1-w5
+#' @return Numeric composite score
+compute_utility_score <- function(seed_connectivity, bridge_score,
+                                   citation_velocity, fwci, ubiquity_penalty,
+                                   weights) {
+  # Build components: name, value, weight, is_penalty
+  components <- list(
+    list(val = seed_connectivity, w = weights$w1, penalty = FALSE),
+    list(val = bridge_score,      w = weights$w2, penalty = FALSE),
+    list(val = citation_velocity, w = weights$w3, penalty = FALSE),
+    list(val = fwci,              w = weights$w4, penalty = FALSE),
+    list(val = ubiquity_penalty,  w = weights$w5, penalty = TRUE)
+  )
+
+  # Separate available from missing
+  available <- Filter(function(c) !is.null(c$val) && !is.na(c$val), components)
+
+  if (length(available) == 0) return(0)
+
+  # Re-normalize weights for available components
+  total_available_weight <- sum(vapply(available, function(c) c$w, numeric(1)))
+  if (total_available_weight == 0) return(0)
+
+  original_total <- sum(weights$w1, weights$w2, weights$w3, weights$w4, weights$w5)
+  scale_factor <- original_total / total_available_weight
+
+  score <- 0
+  for (comp in available) {
+    adjusted_weight <- comp$w * scale_factor
+    if (comp$penalty) {
+      score <- score - adjusted_weight * comp$val
+    } else {
+      score <- score + adjusted_weight * comp$val
+    }
+  }
+
+  score
+}
+
+#' Normalize a numeric vector to 0-1 range
+#'
+#' @param x Numeric vector
+#' @return Numeric vector scaled to [0, 1]
+normalize_01 <- function(x) {
+  if (length(x) == 0) return(numeric(0))
+  rng <- range(x, na.rm = TRUE)
+  if (rng[1] == rng[2]) return(rep(0.5, length(x)))
+  (x - rng[1]) / (rng[2] - rng[1])
+}
+
+#' Score a pool of candidate papers
+#'
+#' Takes a data frame of candidates with metadata columns and computes
+#' utility scores for each. Normalizes individual components to 0-1 before
+#' combining.
+#'
+#' @param candidates Data frame with columns: paper_id, cited_by_count, year,
+#'   fwci (optional), seed_connectivity (optional), bridge_score (optional)
+#' @param weights Named list with w1-w5 from get_preset_weights()
+#' @return Data frame with added columns: citation_velocity, ubiquity_penalty,
+#'   utility_score, plus normalized versions of each component
+score_candidate_pool <- function(candidates, weights) {
+  n <- nrow(candidates)
+  if (n == 0) return(candidates)
+
+  # Compute raw citation velocity
+  candidates$citation_velocity <- mapply(
+    compute_citation_velocity,
+    candidates$cited_by_count,
+    candidates$year
+  )
+
+  # Compute ubiquity penalty
+  pool_citations <- candidates$cited_by_count
+  candidates$ubiquity_penalty <- vapply(candidates$cited_by_count, function(cc) {
+    compute_ubiquity_penalty(cc, pool_citations)
+  }, numeric(1))
+
+  # Ensure optional columns exist (NA if not provided)
+  if (is.null(candidates$seed_connectivity)) candidates$seed_connectivity <- NA_real_
+  if (is.null(candidates$bridge_score)) candidates$bridge_score <- NA_real_
+
+  # Normalize available components to 0-1
+  candidates$norm_velocity <- normalize_01(candidates$citation_velocity)
+  candidates$norm_ubiquity <- normalize_01(candidates$ubiquity_penalty)
+
+  # Normalize seed_connectivity if available
+  if (any(!is.na(candidates$seed_connectivity))) {
+    candidates$norm_connectivity <- normalize_01(
+      ifelse(is.na(candidates$seed_connectivity), NA_real_, candidates$seed_connectivity)
+    )
+  } else {
+    candidates$norm_connectivity <- NA_real_
+  }
+
+  # Normalize bridge_score if available
+  if (any(!is.na(candidates$bridge_score))) {
+    candidates$norm_bridge <- normalize_01(
+      ifelse(is.na(candidates$bridge_score), NA_real_, candidates$bridge_score)
+    )
+  } else {
+    candidates$norm_bridge <- NA_real_
+  }
+
+  # Normalize FWCI if available
+  if ("fwci" %in% names(candidates) && any(!is.na(candidates$fwci))) {
+    candidates$norm_fwci <- normalize_01(
+      ifelse(is.na(candidates$fwci), NA_real_, candidates$fwci)
+    )
+  } else {
+    candidates$norm_fwci <- NA_real_
+  }
+
+  # Compute composite utility score per paper
+  candidates$utility_score <- mapply(
+    function(conn, bridge, vel, fwci_val, ubiq) {
+      compute_utility_score(conn, bridge, vel, fwci_val, ubiq, weights)
+    },
+    candidates$norm_connectivity,
+    candidates$norm_bridge,
+    candidates$norm_velocity,
+    candidates$norm_fwci,
+    candidates$norm_ubiquity
+  )
+
+  # Sort by utility score descending
+  candidates <- candidates[order(candidates$utility_score, decreasing = TRUE), ]
+  candidates$rank <- seq_len(nrow(candidates))
+
+  candidates
+}

--- a/R/utils_scoring.R
+++ b/R/utils_scoring.R
@@ -126,20 +126,17 @@ compute_utility_score <- function(seed_connectivity, bridge_score,
 
   if (length(available) == 0) return(0)
 
-  # Re-normalize weights for available components
+  # Re-normalize weights for available components to sum to 1.0
   total_available_weight <- sum(vapply(available, function(c) c$w, numeric(1)))
   if (total_available_weight == 0) return(0)
 
-  original_total <- sum(weights$w1, weights$w2, weights$w3, weights$w4, weights$w5)
-  scale_factor <- original_total / total_available_weight
-
   score <- 0
   for (comp in available) {
-    adjusted_weight <- comp$w * scale_factor
+    normalized_weight <- comp$w / total_available_weight
     if (comp$penalty) {
-      score <- score - adjusted_weight * comp$val
+      score <- score - normalized_weight * comp$val
     } else {
-      score <- score + adjusted_weight * comp$val
+      score <- score + normalized_weight * comp$val
     }
   }
 

--- a/R/utils_scoring.R
+++ b/R/utils_scoring.R
@@ -101,7 +101,7 @@ get_preset_weights <- function(mode = "discovery") {
 #' Compute composite utility score with weight re-normalization
 #'
 #' When a scoring component is unavailable (NA/NULL), its weight is excluded
-#' and the remaining weights are re-normalized to sum to the original total.
+#' and the remaining weights are re-normalized to sum to 1.0.
 #' This avoids penalizing papers that lack certain metadata (e.g., preprints
 #' without FWCI, candidates without graph data for bridge scores).
 #'
@@ -124,7 +124,7 @@ compute_utility_score <- function(seed_connectivity, bridge_score,
     list(val = citation_velocity,   w = weights$w3, penalty = FALSE),
     list(val = fwci,                w = weights$w4, penalty = FALSE),
     list(val = ubiquity_penalty,    w = weights$w5, penalty = TRUE),
-    list(val = embedding_similarity, w = weights$w6 %||% 0, penalty = FALSE)
+    list(val = embedding_similarity, w = if (is.null(weights$w6)) 0 else weights$w6, penalty = FALSE)
   )
 
   # Separate available from missing

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Discover and curate academic papers via OpenAlex (240M+ scholarly works).
 
 - **Smart search** - Query across titles, abstracts, or full text
 - **Document type filters** - Filter by article, review, preprint, book, dissertation, dataset
+- **Keyword filters** - Ban or keep keywords from the global panel or directly on any abstract card; promoted keywords appear in the global chip bin
 - **Quality filters** - Exclude retracted papers, flag predatory journals/publishers
 - **Citation filters** - Set minimum citation thresholds
 - **Rich metadata display**:

--- a/README.md
+++ b/README.md
@@ -64,6 +64,18 @@ Explore citation relationships through interactive network graphs.
 - **Save & reload** - Persist networks to database with layout positions preserved
 - **Collapsible legend** - Minimizable legend with shape key and gradient preview
 
+### Research Refiner
+Score, rank, and curate papers against your research focus.
+
+- **Multiple anchor types** - Start from seed papers, a research intent, an entire notebook, or a combination
+- **Tier 1 scoring** - Citation velocity, FWCI, seed connectivity, bridge score, ubiquity penalty
+- **Tier 2 semantic scoring** - BM25 + vector similarity via ragnar against embedded notebooks
+- **Scoring modes** - Discovery (novel connections), Comprehensive (balanced), Emerging (recent high-velocity)
+- **Advanced weights** - Fine-tune component weights with sliders; auto-normalized to sum to 1.0
+- **Curation workflow** - Accept/reject individual papers, batch accept top N, reject bottom half
+- **Import results** - Send curated papers to an existing or new notebook
+- **Notebook anchor** - Use all papers in a notebook as seeds, fetch related candidates from OpenAlex with configurable per-seed limits
+
 ### Dark Mode
 
 Full dark mode support with Catppuccin color palette.

--- a/TODO.md
+++ b/TODO.md
@@ -4,6 +4,17 @@ Future enhancements for the Research Notebook tool, organized by milestone.
 
 ---
 
+## Pending PRs (Resolve Immediately)
+
+- [ ] PR #168: feat: v14.0 citation audit filters + network node sizing [open] — v14-citation-network-evolution
+- [ ] PR #163: feat: v17.0 PDF image pipeline [open] — v17-pdf-image-pipeline
+- [ ] PR #162: feat: v15 AI Infrastructure [open] — v15-ai-infrastructure
+- [ ] PR #161: feat: v13 Search & Discovery — Research Refiner + keyword filtering [open] — v13-search-discovery
+- [ ] PR #156: feat: v12 UX Polish & Onboarding [open] — v12-ux-polish-onboarding
+- [ ] PR #155: fix: restore paper count status line [open] — fix/paper-count-status
+
+---
+
 ## Milestone Execution Notes
 
 - **v12 through v16 are fully parallel** — no cross-milestone dependencies; any can be started independently
@@ -33,6 +44,9 @@ Future enhancements for the Research Notebook tool, organized by milestone.
 
 | Issue | Title | Complexity | Impact |
 |-------|-------|------------|--------|
+| [#176](https://github.com/seanthimons/serapeum/issues/176) | Research Refiner: add index on refiner_results(run_id) | Low | Medium |
+| [#174](https://github.com/seanthimons/serapeum/issues/174) | Research Refiner: batch accept/reject uses per-row DB writes | Low | Medium |
+| [#173](https://github.com/seanthimons/serapeum/issues/173) | Research Refiner: results UI silently caps at 100 papers | Low | Medium |
 | ~~[#151](https://github.com/seanthimons/serapeum/issues/151)~~ | ~~Duplicate keyword ban/keep behavior to per-abstract keywords~~ | ~~Medium~~ | ~~Medium~~ |
 | ~~[#125](https://github.com/seanthimons/serapeum/issues/125)~~ | ~~Update file/document filter types reported by OpenAlex~~ | ~~Medium~~ | ~~Medium~~ |
 | ~~[#11](https://github.com/seanthimons/serapeum/issues/11)~~ | ~~Recursive abstract searching~~ | ~~High~~ | ~~High~~ |

--- a/TODO.md
+++ b/TODO.md
@@ -35,7 +35,8 @@ Future enhancements for the Research Notebook tool, organized by milestone.
 |-------|-------|------------|--------|
 | ~~[#151](https://github.com/seanthimons/serapeum/issues/151)~~ | ~~Duplicate keyword ban/keep behavior to per-abstract keywords~~ | ~~Medium~~ | ~~Medium~~ |
 | ~~[#125](https://github.com/seanthimons/serapeum/issues/125)~~ | ~~Update file/document filter types reported by OpenAlex~~ | ~~Medium~~ | ~~Medium~~ |
-| [#11](https://github.com/seanthimons/serapeum/issues/11) | Recursive abstract searching | High | High |
+| ~~[#11](https://github.com/seanthimons/serapeum/issues/11)~~ | ~~Recursive abstract searching~~ | ~~High~~ | ~~High~~ |
+| ~~[#160](https://github.com/seanthimons/serapeum/issues/160)~~ | ~~Research Refiner: start from notebook option~~ | ~~Medium~~ | ~~High~~ |
 | [#122](https://github.com/seanthimons/serapeum/issues/122) | Follow up research | Low | Low |
 
 ---
@@ -229,6 +230,8 @@ High-effort, high-payoff features for the future.
 - [x] [#6](https://github.com/seanthimons/serapeum/issues/6): Timeline heatmap (v14.0)
 - [x] feat: Community-aware edge weighting for citation network cluster separation
 - [x] [#151](https://github.com/seanthimons/serapeum/issues/151): Per-abstract keyword ban/keep filtering (v13.0)
+- [x] [#11](https://github.com/seanthimons/serapeum/issues/11): Recursive abstract searching — Research Refiner with Tier 1 citation scoring + Tier 2 semantic relevance via ragnar BM25+VSS (v13.0)
+- [x] [#160](https://github.com/seanthimons/serapeum/issues/160): Research Refiner "From Notebook" anchor type — use entire notebook as seed set (v13.0)
 
 ---
 

--- a/TODO.md
+++ b/TODO.md
@@ -33,7 +33,7 @@ Future enhancements for the Research Notebook tool, organized by milestone.
 
 | Issue | Title | Complexity | Impact |
 |-------|-------|------------|--------|
-| [#151](https://github.com/seanthimons/serapeum/issues/151) | Duplicate keyword ban/keep behavior to per-abstract keywords | Medium | Medium |
+| ~~[#151](https://github.com/seanthimons/serapeum/issues/151)~~ | ~~Duplicate keyword ban/keep behavior to per-abstract keywords~~ | ~~Medium~~ | ~~Medium~~ |
 | ~~[#125](https://github.com/seanthimons/serapeum/issues/125)~~ | ~~Update file/document filter types reported by OpenAlex~~ | ~~Medium~~ | ~~Medium~~ |
 | [#11](https://github.com/seanthimons/serapeum/issues/11) | Recursive abstract searching | High | High |
 | [#122](https://github.com/seanthimons/serapeum/issues/122) | Follow up research | Low | Low |
@@ -228,6 +228,7 @@ High-effort, high-payoff features for the future.
 - [x] [#125](https://github.com/seanthimons/serapeum/issues/125): Update file/document filter types reported by OpenAlex (v13.0)
 - [x] [#6](https://github.com/seanthimons/serapeum/issues/6): Timeline heatmap (v14.0)
 - [x] feat: Community-aware edge weighting for citation network cluster separation
+- [x] [#151](https://github.com/seanthimons/serapeum/issues/151): Per-abstract keyword ban/keep filtering (v13.0)
 
 ---
 

--- a/app.R
+++ b/app.R
@@ -220,6 +220,14 @@ ui <- page_sidebar(
         "Check your collection for missing references and gaps",
         placement = "bottom",
         options = list(delay = list(show = 300, hide = 100))
+      ),
+      bslib::tooltip(
+        actionButton("research_refiner", "Research Refiner",
+                     class = "btn-outline-danger",
+                     icon = icon_funnel()),
+        "Score and rank papers against your research anchor",
+        placement = "bottom",
+        options = list(delay = list(show = 300, hide = 100))
       )
     ),
     # Divider between sidebar buttons and saved notebooks
@@ -657,6 +665,12 @@ server <- function(input, output, session) {
     current_view("citation_audit")
   })
 
+  # Research refiner button
+  observeEvent(input$research_refiner, {
+    current_notebook(NULL)
+    current_view("refiner")
+  })
+
   # Import papers button (sidebar)
   observeEvent(input$import_papers, {
     sidebar_import_api$show_import_modal()
@@ -1007,6 +1021,10 @@ server <- function(input, output, session) {
       return(mod_citation_audit_ui("citation_audit"))
     }
 
+    if (view == "refiner") {
+      return(mod_research_refiner_ui("refiner"))
+    }
+
     if (view == "welcome" || is.null(nb_id)) {
       return(
         card(
@@ -1104,6 +1122,17 @@ server <- function(input, output, session) {
   # Citation audit module
   mod_citation_audit_server("citation_audit", con, config_r = effective_config,
     db_path = db_path,
+    navigate_to_notebook = function(notebook_id) {
+      current_notebook(notebook_id)
+      current_view("notebook")
+      notebook_refresh(notebook_refresh() + 1)
+    },
+    notebook_refresh = notebook_refresh
+  )
+
+  # Research refiner module
+  mod_research_refiner_server("refiner", con_r,
+    config_r = effective_config,
     navigate_to_notebook = function(notebook_id) {
       current_notebook(notebook_id)
       current_view("notebook")

--- a/docs/brainstorms/2026-03-13-per-abstract-keyword-filtering.md
+++ b/docs/brainstorms/2026-03-13-per-abstract-keyword-filtering.md
@@ -1,0 +1,33 @@
+---
+date: 2026-03-13
+topic: per-abstract-keyword-filtering
+issue: https://github.com/seanthimons/serapeum/issues/151
+milestone: v13.0 Search & Discovery
+---
+
+# Per-Abstract Keyword Ban/Keep Filtering
+
+## What We're Building
+
+Extend the existing keyword ban/keep system so that keywords displayed on individual abstract cards have the same toggle behavior (neutral → keep → ban) as the global top-30 keyword chip bin. When a user acts on a per-abstract keyword, it promotes into the global chip bin as the single source of truth — immediately filtering existing papers and affecting future searches.
+
+## Why This Approach
+
+Users encounter irrelevant keywords on individual abstracts that never appear in the top-30 global panel. Today there's no way to act on these. Rather than building a separate filtering mechanism, we reuse the existing chip toggle pattern and global state — keeping one mental model for keyword filtering everywhere.
+
+## Key Decisions
+
+- **Same chip UI everywhere**: Per-abstract keywords get the identical ban/keep/neutral toggle interaction as global keywords. No new interaction patterns to learn.
+- **Global chip bin is the single source of truth**: Banning/keeping from an abstract card writes to the same global state the top-30 panel uses.
+- **Chip bin grows beyond 30**: The global bin always shows the top-30 *plus* any user-acted keywords, so users can see and reverse every filtering decision they've made.
+- **Immediate effect on existing papers**: Banning a keyword hides matching papers already in the notebook (not just future searches). Keeping pins them.
+- **Reversible from either location**: A user can undo a ban/keep from the abstract card or the global bin — same state, same result.
+
+## Resolved Questions
+
+- **Visual distinction in global bin?** No — user-promoted keywords blend in with the top-30, no special styling.
+- **Hidden paper count indicator?** No — keep the existing "N included | N excluded" summary in the keyword panel. No new unified counter.
+
+## Next Steps
+
+→ Plan implementation details for the reusable chip component and global state wiring.

--- a/docs/brainstorms/2026-03-13-recursive-abstract-searching.md
+++ b/docs/brainstorms/2026-03-13-recursive-abstract-searching.md
@@ -1,0 +1,125 @@
+---
+date: 2026-03-13
+topic: recursive-abstract-searching
+issue: https://github.com/seanthimons/serapeum/issues/11
+milestone: v13.0 Search & Discovery
+---
+
+# Research Refiner — Recursive Abstract Searching
+
+## The Problem
+
+Serapeum's discovery tools (citation audit, network graph, seed search, query builder) are effective at generating large candidate pools. But users rapidly get overwhelmed by combinatorial explosion — 5 seeds x 100 nodes x 3 iterations produces thousands of papers. Most are topically *relevant* but not *useful*: foundational papers everyone already knows, tangential work, redundant findings. There's no way to separate signal from noise at scale without reading every abstract.
+
+## What We're Building
+
+A dedicated **Research Refiner** module (new sidebar entry) that scores, ranks, and triages a large pool of candidate papers against a user-defined anchor — returning the papers most *useful* to the research narrative, not just the most *relevant* to the field.
+
+The refiner operates in two tiers:
+- **Tier 1 (Metadata scoring)** — fast, cheap, no LLM cost. Composite score from citation velocity, FWCI, graph connectivity, recency, and a ubiquity penalty that suppresses foundational bloat.
+- **Tier 2 (LLM-as-judge)** — optional, user-initiated. Embeds candidates, compares against anchors, and uses an LLM to evaluate narrative utility ("does this abstract add something the current set doesn't cover?").
+
+## Core Concepts
+
+### The Anchor
+
+The anchor defines "what I'm looking for." Users can set any combination of:
+- **Seed paper(s)** — one or more papers that define the research space
+- **Natural language intent** — a description of the research question or narrative goal
+- **Both** — seeds provide the embedding signal, intent provides the evaluative frame
+
+### The Utility Score
+
+Raw citation count is biased toward old, foundational papers. The utility score age-normalizes and structurally weights candidates:
+
+```
+utility_score = w1 * seed_connectivity       # How many anchors connect to this paper
+             + w2 * bridge_score             # Connects otherwise disconnected clusters
+             + w3 * citation_velocity        # citations_per_year, not raw count
+             + w4 * fwci                     # Field-relative impact
+             - w5 * ubiquity_penalty         # Cited by >X% of field = assumed knowledge
+```
+
+The **ubiquity penalty** is the key anti-bloat mechanism — papers that everyone cites are foundational, not discoveries. A 1995 paper with 5000 citations and a 2023 paper with 50 citations may have equal or inverted utility depending on the research question.
+
+### Preset Modes
+
+| Mode | Personality | Favors | Penalizes |
+|------|------------|--------|-----------|
+| **Discovery** | "Find what I'm missing" | Bridge papers, novel connections, emerging work | Foundational bloat, redundancy with existing set |
+| **Comprehensive** | "Build the full picture" | High connectivity, seminal + recent, broad coverage | Nothing penalized heavily — widest net |
+| **Emerging** | "What's new and rising" | Recent papers, high citation velocity, high FWCI | Old papers regardless of impact |
+
+An **Advanced toggle** exposes individual weight sliders for each score component.
+
+## Entry Paths
+
+### Path A: "I already have candidates"
+
+Source: citation audit results, network graph nodes, or query builder output. The candidate pool already exists — the refiner scores and ranks it. Zero additional OpenAlex API cost.
+
+### Path B: "Start from seeds"
+
+User provides seed paper(s) via DOI entry or bulk upload. The system fetches related/citing/cited papers from OpenAlex to build the candidate pool, then scores it. More creative freedom, higher API cost.
+
+Both paths converge at the same scoring + ranking interface.
+
+## Workflow
+
+1. User opens **Research Refiner** from sidebar
+2. **Sets the anchor** — seed paper(s), natural language intent, or both
+3. **Selects candidate source** — existing results (Path A) or fetch from seeds (Path B)
+4. **Chooses mode** — Discovery / Comprehensive / Emerging, with optional Advanced sliders
+5. **Tier 1 runs** — metadata scoring across candidate pool. Fast, no LLM cost.
+6. **Results displayed ranked** — scored list with composite utility score. User can review, accept, reject.
+7. **At ~50-100 papers, modal nudge** — "Want to run deep analysis? This will embed and LLM-score these papers." Includes cost estimate.
+8. **Tier 2 (optional)** — embed candidates, compare against anchors via similarity, LLM evaluates each for narrative utility
+9. **User curates final set** — accepts papers into destination:
+   - Import into an existing notebook (search or document)
+   - Create a new notebook with accepted papers
+
+## Three Interaction Workflows
+
+### Batch Scoring
+System scores everything in the background, presents a ranked list. User reviews top-N and accepts/rejects. Like citation audit but with intelligent ranking.
+
+### Iterative Loop
+Score → user reviews a batch → user feedback (accept/reject) refines scoring → next batch. The system learns what "useful" means for this notebook over successive rounds.
+
+### One-Shot Prune
+User says "clean this up" — system removes everything below a threshold. Undo available. Good for large noisy sets where the user trusts the scoring.
+
+## Architecture Notes
+
+- **Standalone module**: `mod_research_refiner.R` with dedicated sidebar button
+- **Reuses citation audit infrastructure**: candidate fetching, batch OpenAlex calls, progress modals, result storage pattern
+- **Scoring engine is a shared utility**: could be reused by citation audit or network graph in the future
+- **Tier 2 uses existing ragnar/embedding pipeline**: no new embedding infrastructure needed
+- **LLM evaluation reuses chat_completion()**: same cost tracking, model selection
+
+## Key Decisions
+
+- **Dedicated module, not embedded in search notebook**: clean separation, own sidebar entry
+- **Two-tier scoring**: metadata first (free), LLM second (opt-in with cost transparency)
+- **Ubiquity penalty**: actively suppress foundational bloat rather than just boosting recency
+- **Preset modes with optional tuning**: opinionated defaults, power-user escape hatch
+- **Notebook-agnostic output**: user chooses where accepted papers go (existing or new notebook)
+- **Two entry paths**: reuse existing candidates (cheap) or fetch from seeds (flexible)
+
+## Open Questions
+
+- Exact weight defaults for each preset mode — needs tuning against the test seed paper set
+- Ubiquity threshold — what percentage of field citation makes a paper "assumed knowledge"? May vary by field.
+- Tier 2 LLM prompt design — how to frame "narrative utility" evaluation. Needs iteration.
+- Should the iterative loop persist feedback across sessions, or is it session-only like keyword states?
+- Bridge score calculation — requires graph structure. Only available when candidates come from network graph or citation audit, not from raw search results.
+
+## Next Steps
+
+→ Plan implementation, likely phased:
+1. Tier 1 scoring engine + UI shell
+2. Preset modes + Advanced sliders
+3. Path A integration (citation audit / network graph as source)
+4. Path B integration (seed-based fetching)
+5. Tier 2 LLM evaluation
+6. Iterative feedback loop

--- a/docs/plans/2026-03-13-feat-per-abstract-keyword-filtering-plan.md
+++ b/docs/plans/2026-03-13-feat-per-abstract-keyword-filtering-plan.md
@@ -1,0 +1,236 @@
+---
+title: "feat: Per-Abstract Keyword Ban/Keep Filtering"
+type: feat
+date: 2026-03-13
+issue: https://github.com/seanthimons/serapeum/issues/151
+milestone: v13.0 Search & Discovery
+brainstorm: docs/brainstorms/2026-03-13-per-abstract-keyword-filtering.md
+---
+
+# feat: Per-Abstract Keyword Ban/Keep Filtering
+
+## Overview
+
+Extend the existing keyword ban/keep system so that keywords on individual abstract cards have the same 3-state toggle (neutral → include → exclude) as the global keyword panel. When toggled from an abstract card, the keyword promotes into the global chip bin as the single source of truth — immediately filtering existing papers and affecting future display.
+
+## Problem Statement
+
+Users encounter irrelevant keywords on individual abstracts that never appear in the top-30 global panel. Today the only way to act on these is manual paper removal (one by one) or hoping the keyword happens to be in the top 30. A keyword like "nanotechnology" might pollute results but never crack the top 30, leaving the user with no filtering lever.
+
+## Proposed Solution
+
+Make per-abstract keyword badges interactive with the same toggle cycle as the global panel. A click on any keyword — whether in the global panel or on an abstract card — writes to the same `keyword_states` store. The global panel expands beyond 30 to always display user-acted keywords.
+
+## Technical Approach
+
+### Architecture
+
+#### Module Boundary Change
+
+**Current:** `mod_keyword_filter_server()` returns a single reactive (`filtered_papers`). `keyword_states` is fully encapsulated.
+
+**Proposed:** Return a named list (following the `mod_journal_filter_server` pattern at `mod_search_notebook.R:960-961`):
+
+```r
+# mod_keyword_filter.R — new return signature
+return(list(
+  filtered_papers = reactive(filtered_papers()),
+  set_keyword_state = function(keyword, state) {
+    keyword_states[[keyword]] <- state
+  },
+  get_keyword_state = function(keyword) {
+    keyword_states[[keyword]] %||% "neutral"
+  }
+))
+```
+
+**Parent wiring change** in `mod_search_notebook.R`:
+
+```r
+# Before (line 947):
+keyword_filtered_papers <- mod_keyword_filter_server("keyword_filter", papers_data, remaining_count)
+
+# After:
+keyword_filter_result <- mod_keyword_filter_server("keyword_filter", papers_data, remaining_count)
+keyword_filtered_papers <- keyword_filter_result$filtered_papers
+```
+
+#### Delegated Click Handler (No Observer Explosion)
+
+Instead of creating one `observeEvent` per keyword per abstract, use a single delegated handler via `Shiny.setInputValue()`:
+
+```r
+# In abstract detail rendering (mod_search_notebook.R):
+onclick_js <- sprintf(
+  "Shiny.setInputValue('%s', {keyword: '%s', nonce: Math.random()})",
+  ns("abstract_kw_click"),
+  htmltools::htmlEscape(keyword, attribute = TRUE)
+)
+
+tags$span(
+  class = badge_class,
+  style = "cursor: pointer;",
+  onclick = onclick_js,
+  badge_icon,
+  keyword
+)
+```
+
+```r
+# Single observer in mod_search_notebook_server:
+observeEvent(input$abstract_kw_click, {
+  kw <- input$abstract_kw_click$keyword
+  current <- keyword_filter_result$get_keyword_state(kw)
+  new_state <- switch(current,
+    "neutral" = "include",
+    "include" = "exclude",
+    "exclude" = "neutral",
+    "include"
+  )
+  keyword_filter_result$set_keyword_state(kw, new_state)
+})
+```
+
+This avoids per-keyword observers entirely. One observer handles all abstract keyword clicks regardless of how many papers/keywords exist.
+
+#### Expanded Global Panel (Top-30 + User-Acted)
+
+Modify `all_keywords()` in `mod_keyword_filter.R` to include promoted keywords:
+
+```r
+all_keywords <- reactive({
+  # ... existing top-30 computation ...
+  top_30 <- head(kw_df, 30)
+
+  # Add any user-acted keywords not in top-30
+  all_states <- reactiveValuesToList(keyword_states)
+  acted_keywords <- names(all_states)[all_states != "neutral"]
+  promoted <- setdiff(acted_keywords, top_30$keyword)
+
+  if (length(promoted) > 0) {
+    # Get counts for promoted keywords (may be 0 if papers were deleted)
+    promoted_df <- data.frame(
+      keyword = promoted,
+      count = vapply(promoted, function(k) {
+        sum(grepl(k, papers_keywords, fixed = TRUE))
+      }, integer(1)),
+      stringsAsFactors = FALSE
+    )
+    top_30 <- rbind(top_30, promoted_df)
+  }
+
+  top_30
+})
+```
+
+#### Fix Clear Filters
+
+Update the clear handler to iterate ALL keyword states, not just the top-30:
+
+```r
+# mod_keyword_filter.R — clear_filters handler
+observeEvent(input$clear_filters, {
+  all_states <- reactiveValuesToList(keyword_states)
+  for (kw in names(all_states)) {
+    keyword_states[[kw]] <- "neutral"
+  }
+})
+```
+
+### Implementation Phases
+
+#### Phase 1: Module API Extension
+
+**Files:** `R/mod_keyword_filter.R`, `R/mod_search_notebook.R`
+
+- [x] Change `mod_keyword_filter_server` return value from single reactive to named list with `filtered_papers`, `set_keyword_state`, `get_keyword_state`
+- [x] Update parent wiring in `mod_search_notebook_server` to destructure the list (`keyword_filter_result$filtered_papers`)
+- [x] Verify existing keyword toggle behavior is unchanged (regression check)
+
+#### Phase 2: Per-Abstract Badge Rendering
+
+**Files:** `R/mod_search_notebook.R`
+
+- [x] Replace static `span(class = "badge bg-secondary me-1", k)` at `mod_search_notebook.R:1787` with state-aware actionable badges
+- [x] Add `onclick` JavaScript handler using `Shiny.setInputValue` with keyword name payload
+- [x] Reflect current keyword state (neutral/include/exclude) via badge color and icon, reading from `keyword_filter_result$get_keyword_state()`
+- [x] Use same badge classes as global panel: `bg-secondary` (neutral), `bg-success` + `icon_add` (include), `bg-danger` + `icon_minus` (exclude)
+- [x] Add tooltip text matching the global panel pattern ("Click to include", "Click to exclude", "Click to clear filter")
+
+#### Phase 3: Delegated Click Handler
+
+**Files:** `R/mod_search_notebook.R`
+
+- [x] Add single `observeEvent(input$abstract_kw_click, ...)` in `mod_search_notebook_server`
+- [x] On click: read current state via `get_keyword_state`, compute next state, call `set_keyword_state`
+- [x] Trigger detail view re-render so the clicked badge updates visually (the badge color should reflect the new state)
+- [x] Verify that setting keyword state triggers the `keyword_filtered_papers` reactive chain (papers list re-filters)
+
+#### Phase 4: Expanded Global Panel
+
+**Files:** `R/mod_keyword_filter.R`
+
+- [x] Modify `all_keywords()` reactive to union top-30 with any keyword in `keyword_states` that has a non-neutral state
+- [x] Promoted keywords appear after the top-30, ordered by count descending
+- [x] Fix `clear_filters` handler to iterate `reactiveValuesToList(keyword_states)` instead of just `all_keywords()$keyword`
+- [x] Update summary line ("N keywords") to reflect actual displayed count including promoted
+
+#### Phase 5: Edge Cases & Polish
+
+**Files:** `R/mod_keyword_filter.R`, `R/mod_search_notebook.R`
+
+- [x] **Case normalization**: Normalize keywords to lowercase for state storage and matching. Display the original casing from the abstract.
+- [x] **Special character safety**: Escape keyword names in the `onclick` JavaScript handler (`htmltools::htmlEscape` with `attribute = TRUE`)
+- [x] **Detail view when paper filtered out**: Keep detail view open (it reads from `papers_data()`, not `filtered_papers()`). Paper disappears from list but detail remains viewable. User closes manually.
+- [x] **Pagination survival**: When `all_keywords()` recomputes after loading more papers, promoted keywords persist because they're stored in `keyword_states` which is not reset by paper set changes
+- [x] **Promoted keyword with zero papers**: If all papers for a promoted keyword are deleted, the keyword remains in the global panel as long as it has a non-neutral state. Count shows `(0)`. Clearing the filter removes it.
+
+## Acceptance Criteria
+
+### Functional Requirements
+
+- [ ] Per-abstract keyword badges are clickable with 3-state toggle (neutral → include → exclude → neutral)
+- [ ] Clicking a per-abstract keyword updates the global chip bin state
+- [ ] The global chip bin shows top-30 *plus* any user-acted keywords beyond the top 30
+- [ ] Banning a keyword from an abstract card immediately hides matching papers from the list
+- [ ] Including a keyword from an abstract card immediately filters to only matching papers
+- [ ] State changes from the abstract card are reflected in the global panel (and vice versa)
+- [ ] "Clear filters" resets ALL keyword states including promoted keywords
+- [ ] The "N included | N excluded" summary reflects promoted keyword actions
+- [ ] Keywords with special characters (hyphens, parentheses, Unicode) work correctly
+
+### Non-Functional Requirements
+
+- [ ] No per-keyword observers on abstract cards (delegated handler pattern)
+- [ ] No regression in existing global keyword toggle behavior
+- [ ] Detail view remains functional when the viewed paper is filtered out by keyword action
+
+## Dependencies & Risks
+
+**Dependencies:**
+- None — this feature is self-contained within the keyword filter and search notebook modules
+
+**Risks:**
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|-----------|--------|------------|
+| Observer explosion on large paper sets | Low | High | Delegated `Shiny.setInputValue` handler avoids per-keyword observers entirely |
+| Case sensitivity causing inconsistent filtering | Medium | Medium | Normalize to lowercase for matching and state storage |
+| Positional input ID collision between global and abstract badges | Low | High | Global panel uses `kw_N` IDs; abstract badges use delegated handler with no individual IDs |
+| `keyword_states` grows unbounded | Low | Low | Only non-neutral keywords are promoted; clear resets all |
+| Detail view confusion when paper filtered out | Medium | Low | Paper stays in detail view; user closes manually. Matches existing behavior when other filters hide papers |
+
+## Known Limitations (Deferred)
+
+- **No session persistence**: Keyword states (including promoted keywords) are lost on browser refresh. This matches current behavior and is acceptable for v1. Database persistence is a potential follow-up.
+- **No cross-filter interaction indicator**: No message like "3 papers match keyword filter but hidden by year range." Would require filter chain awareness that doesn't currently exist.
+
+## References
+
+- **Brainstorm**: `docs/brainstorms/2026-03-13-per-abstract-keyword-filtering.md`
+- **Global keyword filter module**: `R/mod_keyword_filter.R` (309 lines)
+- **Per-abstract rendering**: `R/mod_search_notebook.R:1775-1791`
+- **Filter chain**: `R/mod_search_notebook.R:947-1245`
+- **Journal filter list pattern (precedent)**: `R/mod_search_notebook.R:960-961`
+- **Icon helpers**: `R/theme_catppuccin.R` (`icon_add`, `icon_minus`, `icon_key`)
+- **Existing observer pattern**: `R/mod_keyword_filter.R:147-179`

--- a/docs/plans/2026-03-13-feat-research-refiner-plan.md
+++ b/docs/plans/2026-03-13-feat-research-refiner-plan.md
@@ -1,0 +1,421 @@
+---
+title: "feat: Research Refiner — Recursive Abstract Scoring & Triage"
+type: feat
+date: 2026-03-13
+issue: https://github.com/seanthimons/serapeum/issues/11
+milestone: v13.0 Search & Discovery
+brainstorm: docs/brainstorms/2026-03-13-recursive-abstract-searching.md
+---
+
+# Research Refiner — Recursive Abstract Scoring & Triage
+
+## Overview
+
+A dedicated **Research Refiner** module (new sidebar entry) that scores, ranks, and triages a large pool of candidate papers against a user-defined anchor. Returns papers most *useful* to the research narrative, not just the most *relevant* to the field.
+
+Two-tier scoring architecture:
+- **Tier 1 (Metadata)** — fast, free, composite score from citation velocity, FWCI, connectivity, and ubiquity penalty
+- **Tier 2 (LLM-as-judge)** — optional, user-initiated, embedding similarity + LLM narrative utility evaluation
+
+## Problem Statement
+
+Serapeum's discovery tools (citation audit, network graph, seed search, query builder) generate large candidate pools — potentially thousands of papers. Most are topically relevant but not useful: foundational papers everyone knows, tangential work, redundant findings. There's no way to separate signal from noise at scale without reading every abstract.
+
+## Proposed Solution
+
+A standalone Shiny module (`mod_research_refiner.R`) with its own sidebar button, accessible from any point in the app. Users define an anchor (what they're looking for), select a candidate source (existing notebook papers or fetch from seeds), choose a scoring mode, and get a ranked list they can curate into notebooks.
+
+## Technical Approach
+
+### Architecture
+
+```
+app.R
+├── sidebar: "Research Refiner" button (btn-outline-flamingo)
+├── current_view("refiner") → mod_research_refiner_ui("refiner")
+└── server: mod_research_refiner_server("refiner", con_r, effective_config, ...)
+
+R/mod_research_refiner.R    # UI + server module
+R/research_refiner.R        # Business logic (scoring engine, candidate fetching)
+R/utils_scoring.R           # Shared scoring utilities (reusable by other modules later)
+```
+
+**Module signature follows existing pattern:**
+
+```r
+# R/mod_research_refiner.R
+mod_research_refiner_ui <- function(id) { ... }
+
+mod_research_refiner_server <- function(id, con_r, config_r,
+                                         notebook_refresh = NULL,
+                                         navigate_to_notebook = NULL) { ... }
+```
+
+**Wiring in app.R** (follows citation audit pattern):
+
+```r
+# Sidebar button
+actionButton("research_refiner", "Research Refiner",
+             class = "btn-outline-flamingo",
+             icon = icon_funnel())
+
+# View routing
+observeEvent(input$research_refiner, {
+  current_notebook(NULL)
+  current_view("refiner")
+})
+
+# In output$main_content renderUI:
+if (view == "refiner") {
+  return(mod_research_refiner_ui("refiner"))
+}
+
+# Server module
+mod_research_refiner_server("refiner", con_r,
+  config_r = effective_config,
+  navigate_to_notebook = function(notebook_id) {
+    current_notebook(notebook_id)
+    current_view("notebook")
+    notebook_refresh(notebook_refresh() + 1)
+  },
+  notebook_refresh = notebook_refresh
+)
+```
+
+### Database Schema
+
+New tables for refiner runs and scored results:
+
+```sql
+CREATE TABLE IF NOT EXISTS refiner_runs (
+  id VARCHAR PRIMARY KEY,
+  anchor_type VARCHAR NOT NULL,        -- 'seeds', 'intent', 'both'
+  anchor_intent VARCHAR,               -- Natural language intent text
+  anchor_seed_ids VARCHAR,             -- JSON array of seed paper_ids
+  source_type VARCHAR NOT NULL,        -- 'notebook', 'fetch'
+  source_notebook_id VARCHAR,          -- Source notebook (Path A)
+  mode VARCHAR DEFAULT 'discovery',    -- 'discovery', 'comprehensive', 'emerging', 'custom'
+  weights VARCHAR,                     -- JSON: {w1: 0.3, w2: 0.2, ...}
+  status VARCHAR DEFAULT 'running',
+  total_candidates INTEGER DEFAULT 0,
+  scored_count INTEGER DEFAULT 0,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  completed_at TIMESTAMP
+)
+
+CREATE TABLE IF NOT EXISTS refiner_results (
+  id VARCHAR PRIMARY KEY,
+  run_id VARCHAR NOT NULL,
+  paper_id VARCHAR NOT NULL,           -- OpenAlex work ID
+  title VARCHAR,
+  authors VARCHAR,
+  abstract VARCHAR,
+  year INTEGER,
+  venue VARCHAR,
+  doi VARCHAR,
+  -- Raw metadata
+  cited_by_count INTEGER DEFAULT 0,
+  fwci DOUBLE,
+  -- Computed scores
+  seed_connectivity DOUBLE DEFAULT 0,  -- How many anchors connect
+  bridge_score DOUBLE DEFAULT 0,       -- Cross-cluster connectivity
+  citation_velocity DOUBLE DEFAULT 0,  -- citations_per_year
+  ubiquity_penalty DOUBLE DEFAULT 0,   -- High if foundational bloat
+  utility_score DOUBLE DEFAULT 0,      -- Final composite score
+  -- Tier 2 scores (NULL until LLM evaluation)
+  embedding_similarity DOUBLE,
+  llm_utility_score DOUBLE,
+  llm_rationale VARCHAR,
+  -- User actions
+  user_action VARCHAR DEFAULT 'pending', -- 'pending', 'accepted', 'rejected'
+  FOREIGN KEY (run_id) REFERENCES refiner_runs(id)
+)
+```
+
+### Scoring Engine
+
+Located in `R/utils_scoring.R` — a pure function library with no Shiny dependencies.
+
+```r
+# R/utils_scoring.R
+
+#' Compute citation velocity (citations per year since publication)
+compute_citation_velocity <- function(cited_by_count, year) {
+  age <- max(as.integer(format(Sys.Date(), "%Y")) - year, 1)
+  cited_by_count / age
+}
+
+#' Compute ubiquity penalty
+#' Papers cited by >X% of the candidate pool are "assumed knowledge"
+compute_ubiquity_penalty <- function(cited_by_count, pool_median_citations,
+                                      pool_max_citations, threshold = 0.8) {
+  # Normalize to 0-1 range relative to pool
+  if (pool_max_citations == 0) return(0)
+  normalized <- cited_by_count / pool_max_citations
+  if (normalized > threshold) {
+    (normalized - threshold) / (1 - threshold)  # Scale 0-1 above threshold
+  } else {
+    0
+  }
+}
+
+#' Compute seed connectivity
+#' How many anchor papers cite or are cited by this candidate
+compute_seed_connectivity <- function(paper_id, anchor_refs, anchor_cited_by) {
+  sum(paper_id %in% anchor_refs) + sum(paper_id %in% anchor_cited_by)
+}
+
+#' Compute composite utility score
+compute_utility_score <- function(seed_connectivity, bridge_score,
+                                   citation_velocity, fwci, ubiquity_penalty,
+                                   weights) {
+  weights$w1 * seed_connectivity +
+    weights$w2 * bridge_score +
+    weights$w3 * citation_velocity +
+    weights$w4 * (fwci %||% 0) -
+    weights$w5 * ubiquity_penalty
+}
+
+#' Get preset weights for a mode
+get_preset_weights <- function(mode = "discovery") {
+  switch(mode,
+    discovery = list(w1 = 0.25, w2 = 0.30, w3 = 0.20, w4 = 0.15, w5 = 0.30),
+    comprehensive = list(w1 = 0.30, w2 = 0.10, w3 = 0.20, w4 = 0.30, w5 = 0.05),
+    emerging = list(w1 = 0.10, w2 = 0.15, w3 = 0.40, w4 = 0.25, w5 = 0.20),
+    # Default to discovery
+    list(w1 = 0.25, w2 = 0.30, w3 = 0.20, w4 = 0.15, w5 = 0.30)
+  )
+}
+```
+
+**Preset mode behavior:**
+
+| Mode | w1 (connectivity) | w2 (bridge) | w3 (velocity) | w4 (fwci) | w5 (ubiquity) | Character |
+|------|-------------------|-------------|---------------|-----------|---------------|-----------|
+| Discovery | 0.25 | 0.30 | 0.20 | 0.15 | 0.30 | Bridge papers, novel connections, emerging work |
+| Comprehensive | 0.30 | 0.10 | 0.20 | 0.30 | 0.05 | Broad coverage, high-impact, minimal penalty |
+| Emerging | 0.10 | 0.15 | 0.40 | 0.25 | 0.20 | Recent, fast-rising, high field-relative impact |
+
+### UI Layout
+
+```
+┌──────────────────────────────────────────────────────────────┐
+│ 🔬 Research Refiner                                          │
+│ Score and rank papers against your research anchor           │
+├──────────────────────────────────────────────────────────────┤
+│ STEP 1: Define Anchor                                        │
+│ ┌──────────────────────────────────────────────────────────┐ │
+│ │ Anchor Type: ○ Seed Papers  ○ Research Intent  ○ Both   │ │
+│ │                                                          │ │
+│ │ [Seed paper DOI input / notebook selector]               │ │
+│ │ [Research intent text area]                               │ │
+│ └──────────────────────────────────────────────────────────┘ │
+│                                                              │
+│ STEP 2: Select Candidates                                    │
+│ ┌──────────────────────────────────────────────────────────┐ │
+│ │ Source: ○ From Notebook  ○ Fetch from Seeds              │ │
+│ │ [Notebook selector dropdown] or [Fetch controls]         │ │
+│ │                                        [N candidates]    │ │
+│ └──────────────────────────────────────────────────────────┘ │
+│                                                              │
+│ STEP 3: Scoring Mode                                         │
+│ ┌──────────────────────────────────────────────────────────┐ │
+│ │ Mode: [Discovery ▾]  [▸ Advanced Weights]                │ │
+│ │                                                          │ │
+│ │ (Advanced: 5 sliders for w1-w5 when expanded)            │ │
+│ └──────────────────────────────────────────────────────────┘ │
+│                                                              │
+│ [Score Papers]                                               │
+│                                                              │
+│ RESULTS                                                      │
+│ ┌──────────────────────────────────────────────────────────┐ │
+│ │ Batch: [Accept All Top-N] [Prune Below Threshold]        │ │
+│ │                                                          │ │
+│ │ #1  Paper Title (2023)         Score: 0.87  [✓] [✗]     │ │
+│ │     Authors | Venue | 45 cit/yr | FWCI 3.2              │ │
+│ │                                                          │ │
+│ │ #2  Paper Title (2022)         Score: 0.74  [✓] [✗]     │ │
+│ │     Authors | Venue | 32 cit/yr | FWCI 2.1              │ │
+│ │     ...                                                  │ │
+│ │                                                          │ │
+│ │ [▸ Run Deep Analysis (Tier 2)] — est. $0.04              │ │
+│ └──────────────────────────────────────────────────────────┘ │
+│                                                              │
+│ ACTIONS                                                      │
+│ [Import Accepted → Notebook ▾] [Create New Notebook]         │
+└──────────────────────────────────────────────────────────────┘
+```
+
+### Implementation Phases
+
+#### Phase 1: Scoring Engine + UI Shell
+
+**Goal:** Working Tier 1 scoring with static test data, module wired into app.
+
+**Tasks:**
+- [x] Create `R/utils_scoring.R` with pure scoring functions
+- [x] Create `R/research_refiner.R` with business logic (candidate processing, batch scoring)
+- [x] Create `R/mod_research_refiner.R` with UI shell (anchor setup, mode selector, results table)
+- [x] Add sidebar button in `app.R` and wire view routing
+- [x] Add `refiner_runs` and `refiner_results` tables to `R/db.R`
+- [x] Add icon helper `icon_funnel()` to `R/theme_catppuccin.R`
+- [x] Write unit tests for scoring functions in `tests/testthat/test-utils_scoring.R`
+
+**Files touched:**
+- `R/utils_scoring.R` (new)
+- `R/research_refiner.R` (new)
+- `R/mod_research_refiner.R` (new)
+- `R/theme_catppuccin.R` (add icon_funnel)
+- `R/db.R` (add tables + helpers)
+- `R/cost_tracking.R` (add refiner_eval operation)
+- `app.R` (sidebar button, view routing, module server)
+- `tests/testthat/test-utils_scoring.R` (new)
+
+**Success criteria:**
+- [x] Sidebar button appears and navigates to refiner view
+- [x] Scoring functions produce correct results for known inputs (42 tests pass)
+- [x] DB tables create on startup without errors
+
+#### Phase 2: Path A — Score from Existing Notebook
+
+**Goal:** User can select a search notebook and score its papers against an anchor.
+
+**Tasks:**
+- [x] Implement notebook selector (search notebooks only, like citation audit)
+- [x] Fetch anchor paper metadata from OpenAlex when seed DOI/ID entered
+- [x] Compute seed_connectivity by fetching anchor's referenced_works and cited_by from OpenAlex
+- [x] Score all papers in selected notebook using Tier 1 formula
+- [x] Display scored results as ranked list with accept/reject buttons
+- [x] Persist scores to `refiner_results` table
+- [x] Progress indicator during scoring (withProgress)
+
+**Success criteria:**
+- [ ] Selecting a notebook with 50+ papers scores and ranks them in <5 seconds
+- [ ] Accept/reject state persists across page navigation
+- [ ] Scoring produces sensible rankings (not all tied, not random)
+
+#### Phase 3: Preset Modes + Advanced Sliders
+
+**Goal:** Full mode selection UX with Discovery/Comprehensive/Emerging and Advanced toggle.
+
+**Tasks:**
+- [x] Add mode radio buttons (Discovery/Comprehensive/Emerging)
+- [x] Implement Advanced toggle that reveals 5 weight sliders (w1-w5)
+- [x] Sliders initialize from preset weights when mode changes
+- [ ] Custom slider positions switch mode indicator to "Custom"
+- [x] Re-score button after changing weights
+- [x] Store selected weights in `refiner_runs.weights` as JSON
+
+**Success criteria:**
+- [ ] Switching modes visibly changes ranking order
+- [x] Advanced sliders update in sync with preset selection
+- [ ] Manual slider changes mark mode as "Custom"
+
+#### Phase 4: Path B — Fetch from Seeds
+
+**Goal:** User can provide seed paper(s) and the system fetches related/citing/cited papers to build a candidate pool.
+
+**Tasks:**
+- [x] Add DOI/search input for seed papers (reuse seed discovery pattern)
+- [x] Support multiple seeds (add/remove list)
+- [x] Fetch citing papers, cited papers, and related papers from OpenAlex for each seed
+- [x] De-duplicate across seeds
+- [x] Feed combined pool into scoring pipeline
+- [x] Show candidate count and fetch progress
+
+**Success criteria:**
+- [ ] 3 seed papers produce a de-duplicated candidate pool
+- [ ] Pool is scored identically to Path A
+- [ ] Fetch progress shows paper count accumulating
+
+#### Phase 5: Curation + Notebook Export
+
+**Goal:** Accepted papers can be imported into an existing notebook or a new one.
+
+**Tasks:**
+- [x] "Import Accepted" button with notebook selector dropdown
+- [x] "Create New Notebook" option that creates a search notebook
+- [x] Bulk insert accepted papers into target notebook's abstracts (reuse `create_abstract` pattern)
+- [x] Create chunks for papers with abstracts
+- [x] Navigate to target notebook after import
+- [x] Show import count notification
+
+**Success criteria:**
+- [ ] Accepted papers appear in target notebook after import
+- [ ] No duplicate papers if some already exist in target
+- [ ] Notification confirms import count
+
+#### Phase 6: Tier 2 — LLM Evaluation
+
+**Goal:** Optional deep analysis using embeddings + LLM narrative utility scoring.
+
+**Tasks:**
+- [ ] Modal nudge at 50-100 accepted papers: "Run deep analysis?"
+- [ ] Cost estimate based on paper count and current embedding/chat model pricing
+- [ ] Embed accepted paper abstracts using `get_embeddings()` from `api_openrouter.R`
+- [ ] Embed anchor (seed abstracts + intent text)
+- [ ] Compute cosine similarity between each candidate and anchor embeddings
+- [ ] LLM evaluation: for top-N candidates, use `chat_completion()` to judge narrative utility
+- [ ] LLM prompt: "Given this research anchor: [anchor]. Does this paper add something the current accepted set doesn't cover? Rate 1-5 and explain."
+- [ ] Store `embedding_similarity`, `llm_utility_score`, `llm_rationale` in refiner_results
+- [ ] Display combined score (metadata + LLM) with expandable rationale per paper
+- [ ] Log costs via existing cost tracking
+
+**Files touched:**
+- `R/mod_research_refiner.R` (Tier 2 UI, modal, rationale display)
+- `R/research_refiner.R` (embedding + LLM scoring pipeline)
+- `R/api_openrouter.R` (reuse chat_completion, get_embeddings)
+
+**Success criteria:**
+- [ ] Cost estimate shown before user opts in
+- [ ] LLM rationale is coherent and specific to anchor
+- [ ] Costs tracked in cost_log table
+- [ ] Combined ranking meaningfully differs from metadata-only ranking
+
+## Edge Cases & Mitigations
+
+| Edge Case | Mitigation |
+|-----------|-----------|
+| Empty notebook selected as source | Show "No papers to score" message, disable Score button |
+| Seed paper not found in OpenAlex | Show error toast, allow retry with different DOI |
+| All papers score identically (e.g., no FWCI data) | Fall back to citation velocity + recency; show warning about limited metadata |
+| Bridge score unavailable (no graph structure) | Set bridge_score = 0 for all, note in UI that bridge scoring requires network graph source |
+| Very large candidate pool (>1000 papers) | Pagination on results; Tier 2 only on accepted subset; warn about API costs |
+| Papers with no abstract | Still score on metadata; skip from Tier 2 embedding; flag in results |
+| User re-runs refiner on same source | Create new run; previous run results preserved for comparison |
+| LLM returns unparseable utility score | Default to metadata score; log parse failure |
+| Session timeout during Tier 2 batch | Use mirai async like bulk import; results saved per-paper as scored |
+
+## Open Questions (Deferred to Tuning)
+
+1. **Weight defaults** — Initial presets above are starting points; needs tuning against real seed paper sets
+2. **Ubiquity threshold** — Hardcoded at 0.8 normalized citation ratio; may need field-specific calibration
+3. **Tier 2 prompt engineering** — "Narrative utility" framing needs iteration; may need few-shot examples
+4. **Iterative feedback loop** — Deferred to post-MVP; Phase 1-6 covers batch scoring only
+5. **One-shot prune** — Can be added as a threshold slider + "Remove below" button after Phase 3
+
+## Dependencies & Prerequisites
+
+- OpenAlex API access (email configured) — required for all paths
+- OpenRouter API key — required only for Tier 2
+- Existing search notebooks with papers — required for Path A
+- `icon_funnel()` or similar icon — needs to be added to `utils_icons.R`
+
+## References
+
+### Internal References
+- Module pattern: `R/mod_citation_audit.R` (closest architectural match)
+- Business logic separation: `R/citation_audit.R` (scoring engine pattern)
+- Sidebar wiring: `app.R:161-224` (button layout), `app.R:654-658` (view routing)
+- View rendering: `app.R:971-1008` (main_content switch)
+- Module server wiring: `app.R:1105-1113` (citation audit server call)
+- DB schema: `R/db.R:62-76` (abstracts table), `R/db.R:237-268` (audit tables pattern)
+- API clients: `R/api_openalex.R` (OpenAlex), `R/api_openrouter.R:37-63` (chat_completion), `R/api_openrouter.R:70-80` (get_embeddings)
+- Progress pattern: `R/citation_audit.R:6-38` (file-based progress)
+- Paper creation: `R/db.R:502` (create_abstract)
+
+### Brainstorm
+- `docs/brainstorms/2026-03-13-recursive-abstract-searching.md`
+
+### Issue
+- https://github.com/seanthimons/serapeum/issues/11

--- a/docs/plans/2026-03-13-uat-research-refiner.md
+++ b/docs/plans/2026-03-13-uat-research-refiner.md
@@ -1,12 +1,37 @@
 ---
 title: "UAT: Research Refiner Module"
 date: 2026-03-13
+uat_date: 2026-03-15
 feature: Research Refiner (Phases 1-5)
 commit: 351743a
 branch: v13-search-discovery
 ---
 
 # UAT: Research Refiner Module
+
+## UAT Results Summary (2026-03-15)
+
+| Test | Result | Notes |
+|------|--------|-------|
+| UAT-1 | PASS | |
+| UAT-2 | PASS | Fixed: email lookup missed DB setting |
+| UAT-3 | PASS | 52 candidates scored |
+| UAT-4 | PASS | Minimal shift with 1 seed — expected |
+| UAT-5 | PASS | |
+| UAT-6 | PASS | |
+| UAT-7 | PASS | |
+| UAT-8 | PASS | Intent text has no scoring impact (follow-up) |
+| UAT-9 | PASS | Fixed: observer stacking, NULL/NA guard, button classes, rank badges |
+| UAT-10 | PASS | Fixed: batch accept now respects prior rejections |
+| UAT-11 | PASS | |
+| UAT-12 | PASS | |
+| UAT-13 | PASS | |
+| UAT-14 | SKIPPED | No preprint-heavy notebook available |
+| UAT-15 | PASS | |
+| UAT-16 | PASS | |
+| UAT-17 | SKIPPED | |
+
+**Bugs fixed:** 7 (email lookup, observer stacking, NULL/NA guard, button classes, rank badges, batch curation state, weight normalization)
 
 ## Context
 
@@ -279,3 +304,33 @@ The Research Refiner is a new standalone Shiny module that scores, ranks, and tr
 **Expected:**
 - Sliders update when mode changes
 - Slider labels match component names (Seed Connectivity, Bridge Score, etc.)
+
+---
+
+## Follow-up Items
+
+1. **Advanced weights need tooltips.** Each weight slider should have a tooltip explaining what the component measures and how it affects ranking (e.g., "Seed Connectivity: proportion of seed papers that cite or are cited by this candidate").
+
+2. **Intent text does not affect scoring.** In "Both" and "Research Intent" modes, the intent is saved as metadata but never used in `score_candidate_pool()`. For intent to influence rankings, a semantic similarity component is needed (e.g., embed intent + compare to abstracts). Currently intent-only mode just drops seed connectivity and scores on citation metrics alone — the intent text is ignored. Consider either adding a Tier 2 semantic signal or making the UI clearer that intent is metadata-only for now.
+
+---
+
+## Review Concerns
+
+_Flagged during plan review — to be validated against implementation before UAT execution._
+
+1. **Weight values in UAT-17 don't sum to 1.0.** Discovery defaults sum to 1.20, Emerging to 1.10. Either the listed values are wrong, or the plan should note that raw weights are re-normalized (consistent with the Context section). Verify against `utils_scoring.R`.
+
+2. **UAT-12 conflates import and idempotency.** "Run import again — no duplicates created" tests different logic (dedup check) than the initial import flow. Consider splitting into a separate case if dedup logic is non-trivial.
+
+3. **UAT-7 acceptance criterion is weak.** "Candidate count should be >0 (depends on seed paper)" is untestable if the seed has no connections. Specify a known seed DOI that guarantees results, or define a fallback assertion.
+
+4. **No UAT covers score persistence (DB round-trip).** `refiner_runs` and `refiner_results` tables are listed as files under test, but no case verifies that scores persist across sessions or that re-opening a previous run restores results.
+
+5. **No UAT covers network failure handling.** What happens when OpenAlex is unreachable during DOI resolution (UAT-2) or candidate fetching (UAT-7)? Graceful error vs. crash.
+
+6. **UAT-6 anchor type label should be verified.** "Research Intent" must match the actual UI label in `mod_research_refiner.R`.
+
+7. **UAT-3 "cit/yr" badge** — confirm this metric is computed and rendered by the module (not mentioned in the scoring engine description).
+
+8. **UAT-10 "Accept Top 25"** — if the button label is dynamic based on result count, the test should note the expected label format.

--- a/docs/plans/2026-03-13-uat-research-refiner.md
+++ b/docs/plans/2026-03-13-uat-research-refiner.md
@@ -1,0 +1,281 @@
+---
+title: "UAT: Research Refiner Module"
+date: 2026-03-13
+feature: Research Refiner (Phases 1-5)
+commit: 351743a
+branch: v13-search-discovery
+---
+
+# UAT: Research Refiner Module
+
+## Context
+
+The Research Refiner is a new standalone Shiny module that scores, ranks, and triages candidate papers against a user-defined anchor. It uses a Tier 1 metadata-only scoring engine with five components: seed connectivity, bridge score, citation velocity, FWCI, and ubiquity penalty. When any component is unavailable (e.g., no FWCI for preprints, no graph data for bridge scores), its weight is excluded and remaining weights are re-normalized — no fake data is injected.
+
+### Files Under Test
+
+- `R/utils_scoring.R` — Pure scoring functions
+- `R/research_refiner.R` — Business logic (candidate fetching, connectivity computation)
+- `R/mod_research_refiner.R` — Shiny module UI + server
+- `app.R` — Sidebar button, view routing, module wiring
+- `R/db.R` — `refiner_runs` and `refiner_results` tables + helpers
+
+### Prerequisites
+
+- At least one search notebook with 20+ papers
+- OpenAlex email configured in Settings
+- (Optional) A known paper DOI for seed testing, e.g. `10.1038/s41586-021-03819-2`
+
+---
+
+## Tier 1: Core Scoring
+
+### UAT-1: Module loads from sidebar
+
+**Steps:**
+1. Start the app
+2. Click "Research Refiner" button in the sidebar
+
+**Expected:**
+- Refiner view loads with three cards: Define Anchor, Select Candidates, Scoring Mode
+- No console errors
+- "Score Papers" button visible at bottom
+
+---
+
+### UAT-2: Add seed paper by DOI
+
+**Steps:**
+1. In Step 1, ensure anchor type is "Seed Papers"
+2. Enter a DOI (e.g., `10.1038/s41586-021-03819-2`) in the seed input
+3. Click "Add Seed"
+
+**Expected:**
+- Paper resolves from OpenAlex — title, year, and citation count displayed
+- Input field clears after successful add
+- Notification confirms the add
+
+---
+
+### UAT-3: Score papers from notebook
+
+**Steps:**
+1. Add a seed paper (UAT-2)
+2. In Step 2, select "From Notebook" and pick a search notebook with 20+ papers
+3. Leave mode as "Discovery"
+4. Click "Score Papers"
+
+**Expected:**
+- Progress indicator appears during scoring
+- Results card appears with ranked list
+- Each result shows: rank badge, title, authors, year, venue
+- Metadata badges visible: citation count, cit/yr, FWCI (where available), seed links (where >0)
+- Score badge (e.g., "Score: 0.xxx") on each result
+- Results are sorted descending by score
+- Notification shows "Scored N candidates"
+
+---
+
+### UAT-4: Mode switching changes rankings
+
+**Steps:**
+1. Complete UAT-3 (scored with Discovery mode)
+2. Note the top 5 papers and their scores
+3. Switch mode to "Emerging"
+4. Click "Score Papers" again
+5. Note the top 5 papers and their scores
+
+**Expected:**
+- Ranking order differs between Discovery and Emerging
+- Emerging mode should favor recent papers with high citation velocity
+- Discovery mode should favor bridge papers and novel connections
+
+---
+
+## Tier 2: Anchor & Source Variations
+
+### UAT-5: Multiple seed management
+
+**Steps:**
+1. Add seed paper A by DOI
+2. Add seed paper B by DOI
+3. Try adding seed paper A again
+
+**Expected:**
+- Both seeds shown in list with remove buttons
+- Duplicate add shows warning "This paper is already added as a seed"
+- Click remove on seed A — only seed B remains
+- Click "Clear All" — list empties
+
+---
+
+### UAT-6: Intent-only anchor
+
+**Steps:**
+1. Switch anchor type to "Research Intent"
+2. Enter intent text: "How do large language models improve clinical decision support?"
+3. Select a notebook source
+4. Click "Score Papers"
+
+**Expected:**
+- Scoring completes without errors
+- Warning notification about seed connectivity being unavailable
+- Results ranked by available signals (citation velocity, FWCI, ubiquity)
+
+---
+
+### UAT-7: Fetch from seeds (Path B)
+
+**Steps:**
+1. Add 1 seed paper
+2. Switch source to "Fetch from Seeds"
+3. Click "Score Papers"
+
+**Expected:**
+- Progress indicator shows "Fetching papers for seed 1/1"
+- Candidates fetched from OpenAlex (citing + cited + related)
+- Results displayed and scored
+- Candidate count should be >0 (depends on seed paper)
+
+---
+
+### UAT-8: Combined anchor (seeds + intent)
+
+**Steps:**
+1. Switch anchor type to "Both"
+2. Add a seed paper AND enter intent text
+3. Score from notebook
+
+**Expected:**
+- No errors — both anchor components accepted
+- Scoring proceeds normally
+
+---
+
+## Tier 3: Curation & Export
+
+### UAT-9: Accept/reject individual papers
+
+**Steps:**
+1. Score a notebook (UAT-3)
+2. Click the check button on paper #1 — should turn green (accepted)
+3. Click the check button on paper #1 again — should revert to default (pending)
+4. Click the X button on paper #3 — should turn red (rejected)
+5. Click the X button on paper #3 again — should revert to pending
+
+**Expected:**
+- Toggle behavior: accept/reject toggles between active state and pending
+- Visual feedback: accepted = green background, rejected = red background, pending = no color
+
+---
+
+### UAT-10: Batch accept top N
+
+**Steps:**
+1. Score a notebook with 30+ papers
+2. Click "Accept Top 25"
+
+**Expected:**
+- First 25 results show green/accepted state
+- Notification: "Accepted top 25 papers"
+- Remaining papers unchanged
+
+---
+
+### UAT-11: Reject bottom half
+
+**Steps:**
+1. Score a notebook with 20+ papers
+2. Click "Reject Bottom Half"
+
+**Expected:**
+- Bottom 50% of results show red/rejected state
+- Top 50% unchanged
+- Notification shows count of rejected papers
+
+---
+
+### UAT-12: Import accepted into existing notebook
+
+**Steps:**
+1. Score and accept some papers (UAT-10)
+2. In the curation section, select an existing notebook from the dropdown
+3. Click "Import Papers"
+
+**Expected:**
+- Progress indicator during import
+- Notification: "Imported N papers into notebook"
+- App navigates to the target notebook
+- Imported papers visible in the notebook
+- Run import again — no duplicates created
+
+---
+
+### UAT-13: Import into new notebook
+
+**Steps:**
+1. Score and accept some papers
+2. Select "Create New Notebook" in dropdown
+3. Enter name "Refined Results"
+4. Click "Import Papers"
+
+**Expected:**
+- New notebook created and appears in sidebar
+- App navigates to new notebook
+- Accepted papers present in the notebook
+
+---
+
+## Tier 4: Edge Cases
+
+### UAT-14: All papers lack FWCI
+
+**Steps:**
+1. Score a notebook where most/all papers have NULL FWCI (common for preprint-heavy collections)
+
+**Expected:**
+- Warning: "FWCI data unavailable for all papers — excluded from scoring"
+- Rankings still differentiated (not all tied)
+- Scores based on remaining signals (velocity, connectivity, ubiquity)
+
+---
+
+### UAT-15: No seeds with "seeds" anchor type
+
+**Steps:**
+1. Leave anchor type as "Seed Papers"
+2. Do NOT add any seeds
+3. Click "Score Papers"
+
+**Expected:**
+- Validation message: "Please add at least one seed paper"
+- No scoring attempted
+
+---
+
+### UAT-16: Empty notebook
+
+**Steps:**
+1. Create an empty search notebook
+2. Select it as source in the refiner
+3. Click "Score Papers"
+
+**Expected:**
+- Message: "No candidates found to score"
+- No results rendered
+
+---
+
+## Advanced Weights (Optional)
+
+### UAT-17: Advanced slider sync
+
+**Steps:**
+1. Check "Show Advanced Weights"
+2. Observe slider values match Discovery defaults (w1=0.25, w2=0.30, w3=0.20, w4=0.15, w5=0.30)
+3. Switch mode to "Emerging"
+4. Observe sliders update to Emerging values (w1=0.10, w2=0.15, w3=0.40, w4=0.25, w5=0.20)
+
+**Expected:**
+- Sliders update when mode changes
+- Slider labels match component names (Seed Connectivity, Bridge Score, etc.)

--- a/docs/plans/2026-03-13-uat-research-refiner.md
+++ b/docs/plans/2026-03-13-uat-research-refiner.md
@@ -20,7 +20,7 @@ branch: v13-search-discovery
 | UAT-5 | PASS | |
 | UAT-6 | PASS | |
 | UAT-7 | PASS | |
-| UAT-8 | PASS | Intent text has no scoring impact (follow-up) |
+| UAT-8 | PASS | Intent now affects scoring via Tier 2 semantic similarity |
 | UAT-9 | PASS | Fixed: observer stacking, NULL/NA guard, button classes, rank badges |
 | UAT-10 | PASS | Fixed: batch accept now respects prior rejections |
 | UAT-11 | PASS | |
@@ -31,7 +31,22 @@ branch: v13-search-discovery
 | UAT-16 | PASS | |
 | UAT-17 | SKIPPED | |
 
-**Bugs fixed:** 7 (email lookup, observer stacking, NULL/NA guard, button classes, rank badges, batch curation state, weight normalization)
+**Bugs fixed:** 10
+1. Email lookup — DB setting not checked
+2. Observer stacking — accept/reject handlers recreated reactively
+3. NULL/NA guard — user_action column missing from in-memory dataframe
+4. Button classes — Shiny btn-default overriding outline variants
+5. Rank badges — rank column lost after DB read-back
+6. Batch curation — Accept/Reject now respect prior curation state
+7. Weight normalization — scores always normalize to 1.0
+8. Infinite notification loop — reindex result handler reactive dependency
+9. NA abstracts crash — ragnar embedding skips papers without abstract text
+10. Embedding similarity not saved — DB save hardcoded NA instead of reading computed values
+
+**Post-UAT features added:**
+- Tier 2 semantic scoring via ragnar BM25+VSS hybrid retrieval
+- "From Notebook" anchor type with per-seed candidate slider
+- UUID-to-OpenAlex paper ID mapping for ragnar origin resolution
 
 ## Context
 

--- a/tests/testthat/test-utils_scoring.R
+++ b/tests/testthat/test-utils_scoring.R
@@ -1,0 +1,249 @@
+library(testthat)
+
+# Source required files from project root
+project_root <- normalizePath(file.path(dirname(dirname(getwd())), "."), mustWork = FALSE)
+if (!file.exists(file.path(project_root, "R", "utils_scoring.R"))) {
+  project_root <- getwd()
+}
+
+source(file.path(project_root, "R", "utils_scoring.R"))
+
+# ============================================================================
+# citation velocity
+# ============================================================================
+
+test_that("compute_citation_velocity calculates citations per year", {
+  current_year <- as.integer(format(Sys.Date(), "%Y"))
+
+  # 100 citations over 10 years = 10 per year
+  expect_equal(compute_citation_velocity(100, current_year - 10), 10)
+
+  # Paper from this year: age clamped to 1
+
+  expect_equal(compute_citation_velocity(50, current_year), 50)
+
+  # Zero citations
+  expect_equal(compute_citation_velocity(0, current_year - 5), 0)
+})
+
+# ============================================================================
+# ubiquity penalty
+# ============================================================================
+
+test_that("compute_ubiquity_penalty returns 0 for below-threshold papers", {
+  pool <- c(10, 20, 30, 40, 50, 60, 70, 80, 90, 100)
+  # The 90th percentile is 91 (quantile default method)
+  # Papers below that should have 0 penalty
+  expect_equal(compute_ubiquity_penalty(50, pool), 0)
+  expect_equal(compute_ubiquity_penalty(10, pool), 0)
+})
+
+test_that("compute_ubiquity_penalty penalizes high-citation papers", {
+  pool <- c(10, 20, 30, 40, 50, 60, 70, 80, 90, 100)
+  # 100 is the max and above 90th percentile — should have positive penalty
+  penalty <- compute_ubiquity_penalty(100, pool)
+  expect_gt(penalty, 0)
+  expect_lte(penalty, 1)
+})
+
+test_that("compute_ubiquity_penalty handles empty pool", {
+  expect_equal(compute_ubiquity_penalty(100, numeric(0)), 0)
+})
+
+test_that("compute_ubiquity_penalty handles all-zero pool", {
+  expect_equal(compute_ubiquity_penalty(0, c(0, 0, 0)), 0)
+})
+
+# ============================================================================
+# seed connectivity
+# ============================================================================
+
+test_that("compute_seed_connectivity counts forward connections", {
+  anchor_refs <- list(
+    c("W1", "W2", "W3"),  # seed 1 cites W1, W2, W3
+    c("W2", "W4")          # seed 2 cites W2, W4
+  )
+  anchor_ids <- c("S1", "S2")
+
+  # W2 is cited by both seeds
+  expect_equal(compute_seed_connectivity("W2", anchor_refs, anchor_ids), 2)
+
+  # W1 is cited by seed 1 only
+  expect_equal(compute_seed_connectivity("W1", anchor_refs, anchor_ids), 1)
+
+  # W5 is not cited by any seed
+  expect_equal(compute_seed_connectivity("W5", anchor_refs, anchor_ids), 0)
+})
+
+test_that("compute_seed_connectivity counts backward connections", {
+  anchor_refs <- list(character(0))
+  anchor_ids <- c("S1", "S2")
+
+  # Candidate cites both seeds
+  expect_equal(
+    compute_seed_connectivity("W1", anchor_refs, anchor_ids,
+                               candidate_refs = c("S1", "S2")),
+    2
+  )
+
+  # Candidate cites one seed
+  expect_equal(
+    compute_seed_connectivity("W1", anchor_refs, anchor_ids,
+                               candidate_refs = c("S1", "X1")),
+    1
+  )
+})
+
+test_that("compute_seed_connectivity combines forward and backward", {
+  anchor_refs <- list(c("W1"))  # seed cites W1
+  anchor_ids <- c("S1")
+
+  # W1 is cited by the seed (forward=1) AND cites the seed back (backward=1)
+  expect_equal(
+    compute_seed_connectivity("W1", anchor_refs, anchor_ids,
+                               candidate_refs = c("S1")),
+    2
+  )
+})
+
+# ============================================================================
+# preset weights
+# ============================================================================
+
+test_that("get_preset_weights returns valid weights for all modes", {
+  for (mode in c("discovery", "comprehensive", "emerging")) {
+    w <- get_preset_weights(mode)
+    expect_true(is.list(w))
+    expect_named(w, c("w1", "w2", "w3", "w4", "w5"))
+    # All weights should be positive
+    expect_true(all(vapply(w, function(x) x >= 0, logical(1))))
+  }
+})
+
+test_that("get_preset_weights returns discovery for unknown mode", {
+  expect_equal(get_preset_weights("unknown"), get_preset_weights("discovery"))
+})
+
+# ============================================================================
+# utility score with re-normalization
+# ============================================================================
+
+test_that("compute_utility_score works with all components available", {
+  weights <- list(w1 = 0.2, w2 = 0.2, w3 = 0.2, w4 = 0.2, w5 = 0.2)
+  score <- compute_utility_score(1.0, 0.5, 0.8, 0.6, 0.3, weights)
+  # Expected: 0.2*1.0 + 0.2*0.5 + 0.2*0.8 + 0.2*0.6 - 0.2*0.3 = 0.52
+  expect_equal(score, 0.52, tolerance = 1e-10)
+})
+
+test_that("compute_utility_score re-normalizes when FWCI is NA", {
+  weights <- list(w1 = 0.2, w2 = 0.2, w3 = 0.2, w4 = 0.2, w5 = 0.2)
+
+  # With FWCI NA: only 4 components active (w1+w2+w3+w5 = 0.8)
+  # Scale factor: 1.0 / 0.8 = 1.25
+  # Score: 1.25 * (0.2*1.0 + 0.2*0.5 + 0.2*0.8 - 0.2*0.3)
+  #      = 1.25 * (0.2 + 0.1 + 0.16 - 0.06) = 1.25 * 0.4 = 0.5
+  score <- compute_utility_score(1.0, 0.5, 0.8, NA, 0.3, weights)
+  expect_equal(score, 0.5, tolerance = 1e-10)
+})
+
+test_that("compute_utility_score re-normalizes when bridge and FWCI are NA", {
+  weights <- list(w1 = 0.2, w2 = 0.2, w3 = 0.2, w4 = 0.2, w5 = 0.2)
+
+  # Only w1, w3, w5 active (total = 0.6). Scale = 1.0 / 0.6 = 5/3
+  # Score: (5/3) * (0.2*1.0 + 0.2*0.8 - 0.2*0.3)
+  #      = (5/3) * (0.2 + 0.16 - 0.06) = (5/3) * 0.3 = 0.5
+  score <- compute_utility_score(1.0, NA, 0.8, NA, 0.3, weights)
+  expect_equal(score, 0.5, tolerance = 1e-10)
+})
+
+test_that("compute_utility_score returns 0 when all components are NA", {
+  weights <- list(w1 = 0.2, w2 = 0.2, w3 = 0.2, w4 = 0.2, w5 = 0.2)
+  expect_equal(compute_utility_score(NA, NA, NA, NA, NA, weights), 0)
+})
+
+# ============================================================================
+# normalize_01
+# ============================================================================
+
+test_that("normalize_01 scales to 0-1", {
+  expect_equal(normalize_01(c(0, 5, 10)), c(0, 0.5, 1))
+})
+
+test_that("normalize_01 handles constant values", {
+  expect_equal(normalize_01(c(5, 5, 5)), c(0.5, 0.5, 0.5))
+})
+
+test_that("normalize_01 handles empty input", {
+  expect_equal(normalize_01(numeric(0)), numeric(0))
+})
+
+# ============================================================================
+# score_candidate_pool integration
+# ============================================================================
+
+test_that("score_candidate_pool scores and ranks a small pool", {
+  candidates <- data.frame(
+    paper_id = c("W1", "W2", "W3"),
+    title = c("Paper A", "Paper B", "Paper C"),
+    authors = c("[]", "[]", "[]"),
+    abstract = c(NA, NA, NA),
+    year = c(2020, 2023, 2015),
+    venue = c(NA, NA, NA),
+    doi = c(NA, NA, NA),
+    cited_by_count = c(100, 50, 500),
+    fwci = c(2.0, 3.5, 1.0),
+    referenced_works_count = c(30, 20, 80),
+    stringsAsFactors = FALSE
+  )
+
+  weights <- get_preset_weights("discovery")
+  result <- score_candidate_pool(candidates, weights)
+
+  expect_equal(nrow(result), 3)
+  expect_true("utility_score" %in% names(result))
+  expect_true("rank" %in% names(result))
+  expect_true("citation_velocity" %in% names(result))
+  expect_true("ubiquity_penalty" %in% names(result))
+
+  # Results should be sorted by utility_score descending
+  expect_true(all(diff(result$utility_score) <= 0))
+
+  # Rank should be 1, 2, 3
+  expect_equal(result$rank, 1:3)
+})
+
+test_that("score_candidate_pool handles missing FWCI gracefully", {
+  candidates <- data.frame(
+    paper_id = c("W1", "W2"),
+    title = c("A", "B"),
+    authors = c("[]", "[]"),
+    abstract = c(NA, NA),
+    year = c(2020, 2022),
+    venue = c(NA, NA),
+    doi = c(NA, NA),
+    cited_by_count = c(100, 50),
+    fwci = c(NA_real_, NA_real_),
+    referenced_works_count = c(30, 20),
+    stringsAsFactors = FALSE
+  )
+
+  weights <- get_preset_weights("discovery")
+  result <- score_candidate_pool(candidates, weights)
+
+  # Should still produce scores
+  expect_equal(nrow(result), 2)
+  expect_true(all(!is.na(result$utility_score)))
+})
+
+test_that("score_candidate_pool handles empty data frame", {
+  empty <- data.frame(
+    paper_id = character(0), title = character(0), authors = character(0),
+    abstract = character(0), year = integer(0), venue = character(0),
+    doi = character(0), cited_by_count = integer(0), fwci = double(0),
+    referenced_works_count = integer(0),
+    stringsAsFactors = FALSE
+  )
+
+  result <- score_candidate_pool(empty, get_preset_weights("discovery"))
+  expect_equal(nrow(result), 0)
+})

--- a/tests/testthat/test-utils_scoring.R
+++ b/tests/testthat/test-utils_scoring.R
@@ -114,7 +114,7 @@ test_that("get_preset_weights returns valid weights for all modes", {
   for (mode in c("discovery", "comprehensive", "emerging")) {
     w <- get_preset_weights(mode)
     expect_true(is.list(w))
-    expect_named(w, c("w1", "w2", "w3", "w4", "w5"))
+    expect_named(w, c("w1", "w2", "w3", "w4", "w5", "w6"))
     # All weights should be positive
     expect_true(all(vapply(w, function(x) x >= 0, logical(1))))
   }


### PR DESCRIPTION
## Summary

Completes the v13 Search & Discovery milestone with two major features:

- **Per-abstract keyword ban/keep filtering (#151)** — duplicate global keyword filter behavior to individual abstract cards
- **Research Refiner module (#11, #160)** — score, rank, and curate papers against a research anchor using a two-tier scoring engine

### Research Refiner

New standalone module accessible from the sidebar:

- **4 anchor types**: Seed Papers, Research Intent, Seeds + Intent, From Notebook
- **Tier 1 scoring**: seed connectivity, bridge score, citation velocity, FWCI, ubiquity penalty
- **Tier 2 semantic scoring**: BM25 + vector similarity via ragnar hybrid retrieval against embedded notebooks; temp ragnar store for fetched candidates
- **3 scoring modes**: Discovery, Comprehensive, Emerging — with advanced weight sliders (auto-normalized to 1.0)
- **Curation workflow**: accept/reject individual papers, batch accept top N (respects prior rejections), reject bottom half (respects prior acceptances)
- **Import results**: send curated papers to existing or new notebooks
- **"From Notebook" anchor**: use entire notebook as seed set, fetch candidates from OpenAlex with configurable per-seed limits

### Bug fixes included

- Infinite notification loop in reindex result handler
- NA abstracts crashing ragnar embedding
- Embedding similarity not persisted to DB
- UUID-to-OpenAlex ID mapping for ragnar origin resolution

### Files changed

- `R/mod_research_refiner.R` — new Shiny module (UI + server)
- `R/research_refiner.R` — business logic (candidate fetching, semantic scoring)
- `R/utils_scoring.R` — pure scoring functions
- `R/db.R` — refiner_runs and refiner_results tables
- `R/_ragnar.R` — NA abstract guard
- `R/mod_search_notebook.R` — notification loop fix
- `R/mod_keyword_filter.R` — per-abstract keyword filtering
- `app.R` — sidebar button, view routing, module wiring

## Test plan

- [x] UAT executed: 15/17 passed, 2 skipped (see `docs/plans/2026-03-13-uat-research-refiner.md`)
- [x] 10 bugs found and fixed during UAT
- [x] Tier 2 semantic scoring verified with embedded notebook + research intent
- [x] Smoke test passes (app starts without errors)
- [x] Existing unit tests in `tests/testthat/test-utils_scoring.R`

## PR review fixes

Fixes #177 — double JSON encoding of authors on refiner import
Fixes #178 — keyword state accessors missing tolower() normalization
Fixes #179 — utils_scoring.R %||% dependency on load order
Fixes #180 — docstring incorrectly says "original total" instead of 1.0
Fixes #181 — XSS-adjacent JS injection in keyword onclick handler
Fixes #182 — seed remove-button observers accumulate without teardown