### PR TITLE
fix: v16 uncommitted changes — cost logging, prompt wiring, indexes

### DIFF
--- a/R/cost_tracking.R
+++ b/R/cost_tracking.R
@@ -205,26 +205,31 @@ log_cost <- function(con, operation, model, prompt_tokens, completion_tokens = 0
     "duration_ms" %in% cols
   }, error = function(e) FALSE)
 
-  if (has_duration && !is.null(duration_ms)) {
-    dbExecute(con, "
-      INSERT INTO cost_log (id, session_id, operation, model, prompt_tokens, completion_tokens, total_tokens, estimated_cost, duration_ms)
-      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
-    ", list(
-      id, session_id, operation, model,
-      as.integer(prompt_tokens), as.integer(completion_tokens),
-      as.integer(total_tokens), as.numeric(estimated_cost),
-      as.integer(duration_ms)
-    ))
-  } else {
-    dbExecute(con, "
-      INSERT INTO cost_log (id, session_id, operation, model, prompt_tokens, completion_tokens, total_tokens, estimated_cost)
-      VALUES (?, ?, ?, ?, ?, ?, ?, ?)
-    ", list(
-      id, session_id, operation, model,
-      as.integer(prompt_tokens), as.integer(completion_tokens),
-      as.integer(total_tokens), as.numeric(estimated_cost)
-    ))
-  }
+  tryCatch({
+    if (has_duration && !is.null(duration_ms)) {
+      dbExecute(con, "
+        INSERT INTO cost_log (id, session_id, operation, model, prompt_tokens, completion_tokens, total_tokens, estimated_cost, duration_ms)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+      ", list(
+        id, session_id, operation, model,
+        as.integer(prompt_tokens), as.integer(completion_tokens),
+        as.integer(total_tokens), as.numeric(estimated_cost),
+        as.integer(duration_ms)
+      ))
+    } else {
+      dbExecute(con, "
+        INSERT INTO cost_log (id, session_id, operation, model, prompt_tokens, completion_tokens, total_tokens, estimated_cost)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+      ", list(
+        id, session_id, operation, model,
+        as.integer(prompt_tokens), as.integer(completion_tokens),
+        as.integer(total_tokens), as.numeric(estimated_cost)
+      ))
+    }
+  }, error = function(e) {
+    warning("Failed to log cost: ", e$message)
+    return(invisible(NULL))
+  })
 
   id
 }

--- a/R/mod_settings.R
+++ b/R/mod_settings.R
@@ -1310,6 +1310,11 @@ mod_settings_server <- function(id, con, config_rv) {
       showNotification("Default text loaded. Click Save to confirm reset.", type = "warning")
     })
 
+    # Clear reset_pending when user edits the prompt text
+    observeEvent(input$prompt_text, {
+      if (reset_pending()) reset_pending(FALSE)
+    }, ignoreInit = TRUE)
+
     # Save settings
     observeEvent(input$save, {
       tryCatch({

--- a/R/mod_settings.R
+++ b/R/mod_settings.R
@@ -1205,6 +1205,7 @@ mod_settings_server <- function(id, con, config_rv) {
 
     current_preset_slug <- reactiveVal(NULL)
     reset_pending <- reactiveVal(FALSE)
+    programmatic_update <- reactiveVal(FALSE)
 
     # One observer per preset slug — local() captures slug correctly
     lapply(unlist(PRESET_GROUPS, use.names = FALSE), function(slug) {
@@ -1305,14 +1306,20 @@ mod_settings_server <- function(id, con, config_rv) {
       slug <- current_preset_slug()
       req(slug)
       reset_pending(TRUE)
+      programmatic_update(TRUE)
       default_text <- PROMPT_DEFAULTS[[slug]]
       updateTextAreaInput(session, "prompt_text", value = default_text)
       showNotification("Default text loaded. Click Save to confirm reset.", type = "warning")
     })
 
-    # Clear reset_pending when user edits the prompt text
+    # Clear reset_pending when user manually edits the prompt text
+    # (skip programmatic updates from reset button / version selector)
     observeEvent(input$prompt_text, {
-      if (reset_pending()) reset_pending(FALSE)
+      if (programmatic_update()) {
+        programmatic_update(FALSE)
+      } else if (reset_pending()) {
+        reset_pending(FALSE)
+      }
     }, ignoreInit = TRUE)
 
     # Save settings

--- a/R/rag.R
+++ b/R/rag.R
@@ -167,7 +167,11 @@ build_context <- function(chunks) {
     # Determine source label using safe scalar checks
     source <- "[Source]"
     if (!isTRUE(is.na(doc_name)) && isTRUE(nchar(doc_name) > 0)) {
-      source <- sprintf("[%s, p.%d]", doc_name, page_number)
+      if (!isTRUE(is.na(page_number))) {
+        source <- sprintf("[%s, p.%d]", doc_name, page_number)
+      } else {
+        source <- sprintf("[%s]", doc_name)
+      }
     } else if (!isTRUE(is.na(abstract_title)) && isTRUE(nchar(abstract_title) > 0)) {
       source <- sprintf("[%s]", abstract_title)
     }
@@ -723,7 +727,8 @@ generate_overview_preset <- function(con, config, notebook_id,
   # Helper: "Thorough" Call 1 — Summary only
   call_overview_summary <- function(df) {
     system_prompt <- sprintf(
-      "You are a research summarizer. %s Cover main themes, key findings, and conclusions. Base the summary ONLY on the provided sources. Cite every substantive claim using (Author, Year, p.X) format. For abstracts: (Author, Year, abstract). For missing page numbers: (Author, Year, chunk N).",
+      "You are a research summarizer. %s %s",
+      get_effective_prompt(con, "summarize"),
       depth_instruction
     )
     user_prompt <- sprintf("%s\n\n%s",
@@ -753,7 +758,7 @@ generate_overview_preset <- function(con, config, notebook_id,
 
   # Helper: "Thorough" Call 2 — Key Points only
   call_overview_keypoints <- function(df) {
-    system_prompt <- "You are a research analyst. Extract key points organized by theme from the provided research. Base all content ONLY on the provided sources. Do not invent findings. Cite every substantive claim using (Author, Year, p.X) format. For abstracts: (Author, Year, abstract). For missing page numbers: (Author, Year, chunk N)."
+    system_prompt <- get_effective_prompt(con, "keypoints")
     user_prompt <- sprintf(
       "%s\n\nExtract key points organized under thematic subheadings in this order: Background/Context, Methodology, Findings/Results, Limitations, Future Directions/Gaps. Each subheading: 3-5 bullet points.",
       wrap_sources(df)

--- a/R/rag.R
+++ b/R/rag.R
@@ -724,11 +724,15 @@ generate_overview_preset <- function(con, config, notebook_id,
     })
   }
 
+  # Citation and grounding instructions appended to all overview calls
+  citation_rules <- "Base all content ONLY on the provided sources. Do not invent findings. Cite every substantive claim using (Author, Year, p.X) format. For abstracts: (Author, Year, abstract). For missing page numbers: (Author, Year, chunk N)."
+
   # Helper: "Thorough" Call 1 — Summary only
   call_overview_summary <- function(df) {
     system_prompt <- sprintf(
-      "You are a research summarizer. %s %s",
+      "You are a research summarizer. %s %s %s",
       get_effective_prompt(con, "summarize"),
+      citation_rules,
       depth_instruction
     )
     user_prompt <- sprintf("%s\n\n%s",
@@ -758,7 +762,11 @@ generate_overview_preset <- function(con, config, notebook_id,
 
   # Helper: "Thorough" Call 2 — Key Points only
   call_overview_keypoints <- function(df) {
-    system_prompt <- get_effective_prompt(con, "keypoints")
+    system_prompt <- sprintf(
+      "You are a research analyst. %s %s",
+      get_effective_prompt(con, "keypoints"),
+      citation_rules
+    )
     user_prompt <- sprintf(
       "%s\n\nExtract key points organized under thematic subheadings in this order: Background/Context, Methodology, Findings/Results, Limitations, Future Directions/Gaps. Each subheading: 3-5 bullet points.",
       wrap_sources(df)

--- a/R/themes.R
+++ b/R/themes.R
@@ -332,6 +332,7 @@ generate_custom_scss <- function(name, bg_color, text_color, accent_color, link_
   )
 
   tryCatch({
+    dir.create(themes_dir, recursive = TRUE, showWarnings = FALSE)
     writeLines(scss_content, file_path)
     file_path
   }, error = function(e) NULL)

--- a/TODO.md
+++ b/TODO.md
@@ -6,12 +6,7 @@ Future enhancements for the Research Notebook tool, organized by milestone.
 
 ## Pending PRs (Resolve Immediately)
 
-- [ ] PR #168: feat: v14.0 citation audit filters + network node sizing [open] — v14-citation-network-evolution
-- [ ] PR #163: feat: v17.0 PDF image pipeline [open] — v17-pdf-image-pipeline
-- [ ] PR #162: feat: v15 AI Infrastructure [open] — v15-ai-infrastructure
-- [ ] PR #161: feat: v13 Search & Discovery — Research Refiner + keyword filtering [open] — v13-search-discovery
-- [ ] PR #156: feat: v12 UX Polish & Onboarding [open] — v12-ux-polish-onboarding
-- [ ] PR #155: fix: restore paper count status line [open] — fix/paper-count-status
+- [ ] PR #233: fix: v16 uncommitted changes — cost logging, prompt wiring, indexes [open] — fix/v16-uncommitted-integration -> integration
 
 ---
 
@@ -95,14 +90,13 @@ Future enhancements for the Research Notebook tool, organized by milestone.
 | [#52](https://github.com/seanthimons/serapeum/issues/52) | Quarto citation support exploration | Low | Medium |
 | [#22](https://github.com/seanthimons/serapeum/issues/22) | Audio overview (NotebookLM style) | High | Medium |
 
----
+*PR review follow-ups (from PR #233 review):*
 
-## Pending PRs (Resolve Immediately)
-
-| PR | Title | State | Branch |
-|----|-------|-------|--------|
-| [#163](https://github.com/seanthimons/serapeum/pull/163) | feat: v17.0 PDF image pipeline | open | v17-pdf-image-pipeline -> integration |
-| [#221](https://github.com/seanthimons/serapeum/pull/221) | feat: v16.0 Content & Output Quality milestone | open | gsd/phase-63-prompt-editing-ui -> main |
+| Issue | Title | Complexity | Impact |
+|-------|-------|------------|--------|
+| [#234](https://github.com/seanthimons/serapeum/issues/234) | log_cost returns stale ID when INSERT fails | Low | Medium |
+| [#235](https://github.com/seanthimons/serapeum/issues/235) | Missing trailing semicolon in migration 018 CREATE INDEX | Low | Medium |
+| [#236](https://github.com/seanthimons/serapeum/issues/236) | Redundant role prefix in overview summary system prompt | Low | Low |
 
 ---
 

--- a/docs/reviews/PR-233-r1-2026-03-22.md
+++ b/docs/reviews/PR-233-r1-2026-03-22.md
@@ -1,0 +1,85 @@
+# PR #233 Review: fix: v16 uncommitted changes — cost logging, prompt wiring, indexes
+
+**Branch:** fix/v16-uncommitted-integration -> integration
+**Files changed:** 5 (0 new, 5 modified) | ~43 lines added
+**Mergeability:** CLEAN
+**Review round:** 1
+**Date:** 2026-03-22
+
+---
+
+## HIGH — Must fix before merge
+
+1. **`reset_pending` cleared immediately by programmatic text update** (`R/mod_settings.R:1313-1315`) `[claude]`
+   - The new `observeEvent(input$prompt_text, ...)` fires when `updateTextAreaInput` is called by the Reset button handler (line 1309). Shiny propagates programmatic updates to the input binding, so `reset_pending(FALSE)` runs immediately after `reset_pending(TRUE)` is set. By the time the user clicks Save, `reset_pending()` is always `FALSE`, so `save_prompt` (line 1270) takes the else-branch and saves the default text as a new custom version instead of calling `reset_prompt_to_default()`.
+   - Impact: The Reset workflow is broken — users can never truly reset a prompt (delete custom version from DB). Instead, the default text gets saved as a new version, polluting version history and defeating the purpose of the reset feature.
+   - Fix: Guard the observer so it only clears `reset_pending` on *user-initiated* edits, not programmatic ones. One approach:
+     ```r
+     # Add a flag to distinguish programmatic vs user edits
+     programmatic_update <- reactiveVal(FALSE)
+
+     observeEvent(input$reset_prompt, {
+       # ...existing code...
+       programmatic_update(TRUE)
+       updateTextAreaInput(session, "prompt_text", value = default_text)
+       # ...existing code...
+     })
+
+     observeEvent(input$prompt_text, {
+       if (programmatic_update()) {
+         programmatic_update(FALSE)
+       } else if (reset_pending()) {
+         reset_pending(FALSE)
+       }
+     }, ignoreInit = TRUE)
+     ```
+
+2. **Citation format and grounding instructions lost from overview prompts** (`R/rag.R:728-729, 758`) `[claude]`
+   - `call_overview_summary` replaced its hardcoded system prompt (which included "Base the summary ONLY on the provided sources. Cite every substantive claim using (Author, Year, p.X) format...") with `get_effective_prompt(con, "summarize")`. The default for "summarize" in `PROMPT_DEFAULTS` is a generic instruction that lacks citation format, source-grounding ("ONLY on provided sources"), and hallucination guards.
+   - Similarly, `call_overview_keypoints` replaced its prompt (which included "Do not invent findings", citation format, grounding) with `get_effective_prompt(con, "keypoints")` — another generic prompt lacking these instructions.
+   - Impact: Overview generation loses citation formatting (Author, Year, p.X), source-grounding constraints, and hallucination guards. LLM outputs will degrade — fewer/inconsistent citations and potential hallucinated content.
+   - Fix: Either (a) append the citation/grounding instructions after the effective prompt, or (b) add them to the `PROMPT_DEFAULTS` for these slugs so they're present in both default and custom prompts. Option (a) is safest:
+     ```r
+     # In call_overview_summary:
+     citation_instructions <- "Base the summary ONLY on the provided sources. Cite every substantive claim using (Author, Year, p.X) format. For abstracts: (Author, Year, abstract). For missing page numbers: (Author, Year, chunk N)."
+     system_prompt <- sprintf(
+       "You are a research summarizer. %s %s %s",
+       get_effective_prompt(con, "summarize"),
+       citation_instructions,
+       depth_instruction
+     )
+     ```
+
+## MEDIUM — Should fix
+
+3. **`log_cost` returns `id` even when INSERT fails** (`R/cost_tracking.R:229`) `[claude]` — The tryCatch wraps the INSERT, but `return(invisible(NULL))` in the error handler returns from the anonymous function, not from `log_cost`. The next line (`id`) always executes, returning a UUID that has no corresponding DB row. While callers generally don't use the return value, the function contract is violated. Fix: capture the tryCatch result and return it conditionally, or move `id` inside the tryCatch success path.
+
+4. **Missing trailing semicolon on last CREATE INDEX** (`migrations/018_create_prompt_versions.sql:16`) `[claude]` — The `idx_prompt_versions_slug_date` index statement lacks a terminating semicolon. DuckDB tolerates this for single-statement execution, but if the migration runner concatenates or batches statements, it may fail. Fix: add `;` at end of line 16.
+
+## LOW — Nice to have
+
+5. **Redundant "You are a research summarizer" prefix** (`R/rag.R:727-728`) `[claude]` — The sprintf format hardcodes "You are a research summarizer." before `get_effective_prompt(con, "summarize")`. If a user's custom prompt already includes a role declaration, the system prompt will have a redundant/conflicting role prefix. Minor — the LLM handles this fine, but if switching to effective prompts, the role prefix should come from the prompt itself.
+
+## Verified correct
+
+- **SQL injection prevention**: `cost_tracking.R` uses parameterized queries (`?` placeholders with list binding) — correct
+- **NA page_number handling in build_context**: The new guard (`!isTRUE(is.na(page_number))`) correctly prevents `p.NA` in source labels — well structured
+- **dir.create in themes.R**: `dir.create(themes_dir, recursive = TRUE, showWarnings = FALSE)` before `writeLines` is a proper defensive fix — prevents silent failure when `data/themes/` doesn't exist
+- **Migration indexes**: Index on `(preset_slug)` and composite `(preset_slug, version_date DESC)` are appropriate for the query patterns (lookup by slug, latest version by slug)
+- **tryCatch in cost_tracking.R**: Wrapping the INSERT to prevent cost logging failures from crashing the main workflow is a good pattern (though the return value needs fixing per finding #3)
+
+---
+
+## Issues filed
+
+| # | Issue | Severity | Finding |
+|---|-------|----------|---------|
+| 3 | #234 | MEDIUM | log_cost returns stale ID when INSERT fails |
+| 4 | #235 | MEDIUM | Missing trailing semicolon in migration 018 CREATE INDEX |
+| 5 | #236 | LOW | Redundant role prefix in overview summary system prompt |
+
+---
+
+**Convergence:** Round 1/3 | 2 open HIGHs | 3 issues filed | Verdict: Fix 2 items
+
+**Recommendation:** Fix the two HIGH items before merging. (1) The `reset_pending` observer breaks the prompt reset workflow — guard against programmatic updates. (2) The overview prompt rewiring drops critical citation/grounding instructions that directly affect output quality. The MEDIUM items (log_cost return value, missing semicolon) should be tracked as follow-up issues.

--- a/docs/reviews/PR-233-r2-2026-03-22.md
+++ b/docs/reviews/PR-233-r2-2026-03-22.md
@@ -1,0 +1,47 @@
+# PR #233 Review: fix: v16 uncommitted changes — cost logging, prompt wiring, indexes
+
+**Branch:** fix/v16-uncommitted-integration -> integration
+**Files changed:** 5 (0 new, 5 modified) | ~58 lines added
+**Mergeability:** CLEAN
+**Review round:** 2
+**Date:** 2026-03-22
+
+---
+
+## Round 1 HIGH items — Resolution status
+
+### HIGH #1: `reset_pending` cleared immediately by programmatic text update — **RESOLVED** `[claude]`
+
+The fix adds `programmatic_update <- reactiveVal(FALSE)` and sets it to `TRUE` before `updateTextAreaInput` in the reset handler. The new `observeEvent(input$prompt_text)` checks `programmatic_update()` first — if TRUE, clears the flag without touching `reset_pending`; only clears `reset_pending` on genuine user edits.
+
+Note: the version selector observer (line 1262) also calls `updateTextAreaInput` without setting `programmatic_update(TRUE)`. This is correct behavior — switching versions after clicking Reset is a deliberate user action that should cancel the pending reset.
+
+### HIGH #2: Citation format and grounding instructions lost from overview prompts — **RESOLVED** `[claude]`
+
+The fix extracts `citation_rules` as a shared variable containing grounding constraints, hallucination guards, and citation format instructions. It's appended to both `call_overview_summary` (3 `%s` args: effective prompt + citation rules + depth instruction) and `call_overview_keypoints` (2 `%s` args: effective prompt + citation rules). Format string argument counts match. Citation/grounding instructions are preserved regardless of custom prompt content.
+
+Design note: Thorough mode correctly uses `get_effective_prompt(con, "summarize")` and `get_effective_prompt(con, "keypoints")` (Quick presets), not `"overview"` (Deep preset). This matches Phase 63's architecture — Quick mode uses the combined overview preset, Thorough mode splits into separate task-specific presets.
+
+---
+
+## New issues from fix churn
+
+None. The fixes are minimal and precisely scoped — no new HIGH, MEDIUM, or LOW items introduced.
+
+## Verified correct
+
+- **programmatic_update guard**: Correctly distinguishes programmatic vs user-initiated text changes using a reactiveVal flag — standard Shiny pattern for this problem
+- **citation_rules placement**: Appended after effective prompt, before depth instruction — maintains prompt structure and ensures citation instructions cannot be overridden by user-edited prompts
+- **ignoreInit = TRUE**: The prompt_text observer skips the initial value, preventing false triggers on modal open
+- **Round 1 MEDIUM items**: #3 (log_cost return value, #234), #4 (missing semicolon, #235), #5 (redundant role prefix, #236) remain tracked as issues — not blocking
+
+## Codex findings dismissed
+
+- **Thorough mode uses "summarize"/"keypoints" presets instead of "overview"** — Dismissed: intentional architecture. Phase 63 design separates Quick mode (combined "overview" preset) from Thorough mode (split "summarize" + "keypoints" presets). PRESET_GROUPS confirms "overview" is a Deep preset, "summarize"/"keypoints" are Quick presets. Users can edit all three independently.
+- **log_cost returns UUID after failed INSERT** — Dismissed: duplicate of round 1 finding #3, already filed as issue #234.
+
+---
+
+**Convergence:** Round 2/3 | 0 open HIGHs | 0 new issues filed | Verdict: Ship
+
+**Recommendation:** Both HIGH items from round 1 are properly resolved. No new issues introduced by the fixes. The three MEDIUM/LOW items from round 1 are tracked as issues (#234, #235, #236). This PR is ready to merge.

--- a/migrations/018_create_prompt_versions.sql
+++ b/migrations/018_create_prompt_versions.sql
@@ -10,4 +10,7 @@ CREATE TABLE prompt_versions (
   prompt_text  TEXT      NOT NULL,
   created_at   TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
   PRIMARY KEY (preset_slug, version_date)
-)
+);
+
+CREATE INDEX IF NOT EXISTS idx_prompt_versions_slug ON prompt_versions(preset_slug);
+CREATE INDEX IF NOT EXISTS idx_prompt_versions_slug_date ON prompt_versions(preset_slug, version_date DESC)


### PR DESCRIPTION
## Summary

Recovers uncommitted changes found in the v16 worktree that were never committed before PR #221 was merged.

- **cost_tracking.R**: Wrap `log_cost()` INSERT in `tryCatch` so cost logging failures don't crash the app
- **mod_settings.R**: Clear `reset_pending` flag when user edits prompt text (UX fix — editing after clicking "Reset to Default" no longer leaves stale state)
- **rag.R**: Handle missing page numbers in citation formatting (`[Author]` instead of `[Author, p.NA]`); wire `get_effective_prompt()` into overview summary and keypoints calls so DB-stored prompt overrides apply there too
- **migrations/018_create_prompt_versions.sql**: Add indexes on `preset_slug` and `(preset_slug, version_date DESC)` for lookup performance

## Test plan

- [ ] Verify cost logging doesn't crash on DB errors (e.g., locked DB)
- [ ] Verify prompt editor reset → edit → save flow clears reset_pending correctly
- [ ] Verify overview generation uses DB-stored prompts when available
- [ ] Verify abstracts without page numbers render citations correctly