### PR TITLE
HOTFIX: Fix download button for abstract-imported documents

### DIFF
--- a/R/mod_document_notebook.R
+++ b/R/mod_document_notebook.R
@@ -651,8 +651,35 @@ mod_document_notebook_server <- function(id, con, notebook_id, config) {
         )
       }
 
-      # Register resource path for PDF downloads
+      # Write text files for abstract-imported documents (no PDF on disk)
       pdf_dir <- file.path(".temp", "pdfs", nb_id)
+      text_docs <- which(
+        nchar(docs$filepath) == 0 &
+        !is.na(docs$full_text) & nchar(docs$full_text) > 0
+      )
+      if (length(text_docs) > 0) {
+        dir.create(pdf_dir, recursive = TRUE, showWarnings = FALSE)
+        for (j in text_docs) {
+          txt_path <- file.path(pdf_dir, docs$filename[j])
+          if (!file.exists(txt_path)) {
+            header <- docs$filename[j]
+            if (!is.na(docs$title[j])) header <- docs$title[j]
+            meta <- character(0)
+            if (!is.na(docs$authors[j])) meta <- c(meta, paste("Authors:", docs$authors[j]))
+            if (!is.na(docs$year[j])) meta <- c(meta, paste("Year:", docs$year[j]))
+            if (!is.na(docs$doi[j])) meta <- c(meta, paste("DOI:", docs$doi[j]))
+            content <- paste0(
+              header, "\n",
+              paste(rep("=", nchar(header)), collapse = ""), "\n",
+              if (length(meta) > 0) paste0(paste(meta, collapse = "\n"), "\n\n") else "\n",
+              docs$full_text[j]
+            )
+            writeLines(content, txt_path)
+          }
+        }
+      }
+
+      # Register resource path for PDF/text downloads
       if (dir.exists(pdf_dir)) {
         resource_name <- paste0("pdfs_", gsub("-", "", nb_id))
         addResourcePath(resource_name, normalizePath(pdf_dir))
@@ -795,7 +822,7 @@ mod_document_notebook_server <- function(id, con, notebook_id, config) {
               href = download_url,
               download = doc$filename,
               class = "btn btn-sm btn-outline-secondary py-0 px-1",
-              title = "Download PDF",
+              title = if (is_pdf) "Download PDF" else "Download text",
               icon_download()
             ),
             actionLink(

--- a/R/mod_document_notebook.R
+++ b/R/mod_document_notebook.R
@@ -653,14 +653,16 @@ mod_document_notebook_server <- function(id, con, notebook_id, config) {
 
       # Write text files for abstract-imported documents (no PDF on disk)
       pdf_dir <- file.path(".temp", "pdfs", nb_id)
+      sanitize_filename <- function(name) gsub('[/:*?"<>|\\\\]', "_", name)
       text_docs <- which(
-        nchar(docs$filepath) == 0 &
+        (is.na(docs$filepath) | nchar(docs$filepath) == 0) &
         !is.na(docs$full_text) & nchar(docs$full_text) > 0
       )
       if (length(text_docs) > 0) {
         dir.create(pdf_dir, recursive = TRUE, showWarnings = FALSE)
         for (j in text_docs) {
-          txt_path <- file.path(pdf_dir, docs$filename[j])
+          safe_name <- sanitize_filename(docs$filename[j])
+          txt_path <- file.path(pdf_dir, safe_name)
           if (!file.exists(txt_path)) {
             header <- docs$filename[j]
             if (!is.na(docs$title[j])) header <- docs$title[j]
@@ -708,16 +710,22 @@ mod_document_notebook_server <- function(id, con, notebook_id, config) {
           error = function(e) 0L
         )
 
-        # Build download URL
+        # Build download URL (sanitize filename for non-PDF docs)
         resource_name <- paste0("pdfs_", gsub("-", "", nb_id))
-        download_url <- file.path(resource_name, doc$filename)
+        disk_filename <- if (is_pdf) doc$filename else sanitize_filename(doc$filename)
+        download_url <- file.path(resource_name, disk_filename)
 
         # Register delete observer (once per document ID)
         if (is.null(delete_doc_observers[[doc$id]])) {
           delete_doc_observers[[doc$id]] <- observeEvent(input[[delete_id]], {
             delete_document(con(), doc$id)
             delete_document_chunks_from_ragnar(nb_id, doc$filename)
-            pdf_path <- file.path(".temp", "pdfs", nb_id, doc$filename)
+            disk_name <- if (grepl("\\.pdf$", doc$filename, ignore.case = TRUE)) {
+              doc$filename
+            } else {
+              sanitize_filename(doc$filename)
+            }
+            pdf_path <- file.path(".temp", "pdfs", nb_id, disk_name)
             if (file.exists(pdf_path)) file.remove(pdf_path)
             # Clear figure gallery if showing this doc
             if (identical(selected_fig_doc(), doc$id)) selected_fig_doc(NULL)


### PR DESCRIPTION
## Hotfix

**Issue:** In document notebooks, after importing from the abstract notebook, the downloads button does not actually download any file.

**Root cause:** Abstract-imported documents are created with `filepath=""` and `filename="<title>.txt"` but no file is ever written to disk. The download button renders unconditionally for all documents, pointing to a Shiny resource path that was never registered (because `.temp/pdfs/<nb_id>/` doesn't exist for abstract-only notebooks). Clicking it silently 404s.

**Fix:** Before rendering the document list, detect abstract-imported documents (empty filepath, non-empty full_text) and write formatted `.txt` files containing title, metadata (authors/year/DOI), and abstract text to `.temp/pdfs/<nb_id>/`. The existing resource path registration then picks them up. Also updated download button tooltip to show "Download text" for non-PDF documents.

**Triage findings:**
- Code trace: Download anchor at line 794 rendered unconditionally; `addResourcePath` skipped when pdf_dir doesn't exist; abstract imports store no file on disk
- Git history: Not a regression — design gap since download feature was added (cd0e0bd4, 2026-02-01). No revert candidate.
- Test status: 11 pre-existing failures (schema drift, unrelated). No existing download tests. 537 tests pass.

## Test plan
- [ ] Existing test suite passes (537 pass, 11 pre-existing failures unchanged)
- [ ] Smoke test: app starts without errors
- [ ] Manual: import papers from abstract notebook → document notebook → click download → .txt file downloads with title, metadata, and abstract
- [ ] Manual: upload a PDF → click download → PDF downloads as before