### PR TITLE
HOTFIX: Fix rapi_bind length mismatch when saving citation networks

### DIFF
--- a/R/db.R
+++ b/R/db.R
@@ -1741,7 +1741,8 @@ save_network <- function(con, id = NULL, name, seed_paper_id, seed_paper_title,
     INSERT INTO citation_networks (id, name, seed_paper_id, seed_paper_title, direction, depth, node_limit, palette, seed_paper_ids, source_notebook_id)
     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
   ", list(id, name, seed_paper_id, seed_paper_title, direction,
-          as.integer(depth), as.integer(node_limit), palette, seed_ids_json, source_notebook_id))
+          as.integer(depth), as.integer(node_limit), palette, seed_ids_json,
+          source_notebook_id %||% NA_character_))
 
   # Prepare nodes for bulk insert
   if (nrow(nodes_df) > 0) {
@@ -1757,8 +1758,8 @@ save_network <- function(con, id = NULL, name, seed_paper_id, seed_paper_title,
       cited_by_count = as.integer(nodes_df$cited_by_count),
       x_position = as.numeric(nodes_df$x),
       y_position = as.numeric(nodes_df$y),
-      is_overlap = as.logical(nodes_df$is_overlap %||% FALSE),
-      community = as.character(nodes_df$community %||% NA_character_),
+      is_overlap = as.logical(if (!is.null(nodes_df$is_overlap)) nodes_df$is_overlap else rep(FALSE, nrow(nodes_df))),
+      community = as.character(if (!is.null(nodes_df$community)) nodes_df$community else rep(NA_character_, nrow(nodes_df))),
       stringsAsFactors = FALSE
     )
 

--- a/tests/testthat/test-citation-network.R
+++ b/tests/testthat/test-citation-network.R
@@ -223,6 +223,75 @@ test_that("save_network succeeds with community column after migrations", {
   expect_equal(saved_nodes$community, c("1", "2"))
 })
 
+test_that("save_network succeeds with NULL source_notebook_id and missing columns", {
+  con <- DBI::dbConnect(duckdb::duckdb(), dbdir = ":memory:")
+  on.exit(DBI::dbDisconnect(con, shutdown = TRUE))
+
+  # Same schema as above
+  DBI::dbExecute(con, "CREATE TABLE citation_networks (
+    id VARCHAR PRIMARY KEY, name VARCHAR NOT NULL, seed_paper_id VARCHAR NOT NULL,
+    seed_paper_title VARCHAR NOT NULL, direction VARCHAR NOT NULL, depth INTEGER NOT NULL,
+    node_limit INTEGER NOT NULL, palette VARCHAR DEFAULT 'viridis',
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP, updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    seed_paper_ids VARCHAR, source_notebook_id VARCHAR
+  )")
+  DBI::dbExecute(con, "CREATE TABLE network_nodes (
+    network_id VARCHAR NOT NULL, paper_id VARCHAR NOT NULL,
+    is_seed BOOLEAN DEFAULT FALSE, title VARCHAR NOT NULL, authors VARCHAR,
+    year INTEGER, venue VARCHAR, doi VARCHAR, cited_by_count INTEGER DEFAULT 0,
+    x_position DOUBLE, y_position DOUBLE,
+    is_overlap BOOLEAN DEFAULT FALSE, community VARCHAR,
+    PRIMARY KEY (network_id, paper_id),
+    FOREIGN KEY (network_id) REFERENCES citation_networks(id)
+  )")
+  DBI::dbExecute(con, "CREATE TABLE network_edges (
+    network_id VARCHAR NOT NULL, from_paper_id VARCHAR NOT NULL,
+    to_paper_id VARCHAR NOT NULL,
+    PRIMARY KEY (network_id, from_paper_id, to_paper_id),
+    FOREIGN KEY (network_id) REFERENCES citation_networks(id)
+  )")
+
+  # Nodes WITHOUT is_overlap and community columns (single-seed network scenario)
+  nodes <- data.frame(
+    paper_id = c("W1", "W2"),
+    is_seed = c(TRUE, FALSE),
+    paper_title = c("Seed Paper", "Cited Paper"),
+    authors = c("Auth A", "Auth B"),
+    year = c(2020L, 2021L),
+    venue = c("Journal A", "Journal B"),
+    doi = c("10.1/a", "10.1/b"),
+    cited_by_count = c(100L, 50L),
+    x = c(0.0, 1.0),
+    y = c(0.0, 1.0),
+    stringsAsFactors = FALSE
+  )
+
+  edges <- data.frame(
+    from_paper_id = "W1",
+    to_paper_id = "W2",
+    stringsAsFactors = FALSE
+  )
+
+  # NULL source_notebook_id + missing is_overlap/community — the bug scenario
+  id <- save_network(
+    con, name = "Standalone Network", seed_paper_id = "W1",
+    seed_paper_title = "Seed Paper", direction = "forward",
+    depth = 1, node_limit = 50, palette = "default",
+    nodes_df = nodes, edges_df = edges,
+    seed_paper_ids = c("W1"), source_notebook_id = NULL
+  )
+
+  expect_type(id, "character")
+
+  saved <- DBI::dbGetQuery(con, "SELECT * FROM network_nodes WHERE network_id = ?", list(id))
+  expect_equal(nrow(saved), 2)
+  expect_true(all(!saved$is_overlap))
+  expect_true(all(is.na(saved$community)))
+
+  meta <- DBI::dbGetQuery(con, "SELECT * FROM citation_networks WHERE id = ?", list(id))
+  expect_true(is.na(meta$source_notebook_id))
+})
+
 test_that("enrich_ranked_with_metadata adds fwci for empty metadata", {
   ranked <- data.frame(
     work_id = "W1",


### PR DESCRIPTION
## Hotfix

**Issue:** When saving a citation network: `Error saving network: rapi_bind: Bind parameter values need to have the same length`

**Root cause:** Two issues in `save_network()` (R/db.R):
1. `source_notebook_id = NULL` passed directly to `dbExecute` as a zero-length bind parameter — DuckDB requires all bind params to have equal length
2. `nodes_df$community %||% NA_character_` and `nodes_df$is_overlap %||% FALSE` produce scalar (length-1) fallbacks when columns are absent, mixed with length-N columns in the data.frame passed to `dbWriteTable`

**Fix:**
1. Coerce `NULL` → `NA_character_` for `source_notebook_id` before binding
2. Replace scalar `%||%` fallbacks with `rep()` to ensure length-N vectors

**Triage findings:**
- Code trace: Both `dbExecute` (metadata insert) and `dbWriteTable` (nodes bulk insert) had parameter length mismatches
- Git history: The `community` column addition and missing NULL handling were introduced at different times
- Test status: Existing tests always passed `source_notebook_id = "nb-1"` and included `is_overlap`/`community` columns, masking the bug

## Test plan
- [x] Existing test suite passes (32/32 in test-citation-network.R)
- [x] New regression test: NULL source_notebook_id + missing is_overlap/community columns
- [ ] Manual verification: save a network from Citation Network tab (no notebook context)