### PR TITLE
fix: standalone bugfix batch (6 issues)

### DIFF
--- a/R/api_openrouter.R
+++ b/R/api_openrouter.R
@@ -90,7 +90,7 @@ extract_message_content <- function(msg) {
 
   # Reasoning models (e.g. gpt-5-nano) put output in $reasoning, $content is NULL
 
-  if (is.null(content) || (is.character(content) && all(nchar(content) == 0))) {
+  if (is.null(content) || (is.character(content) && (length(content) == 0 || all(nchar(content) == 0)))) {
     if (!is.null(msg$reasoning)) {
       return(msg$reasoning)
     }

--- a/R/api_openrouter.R
+++ b/R/api_openrouter.R
@@ -90,7 +90,7 @@ extract_message_content <- function(msg) {
 
   # Reasoning models (e.g. gpt-5-nano) put output in $reasoning, $content is NULL
 
-  if (is.null(content) || (is.character(content) && nchar(content) == 0)) {
+  if (is.null(content) || (is.character(content) && all(nchar(content) == 0))) {
     if (!is.null(msg$reasoning)) {
       return(msg$reasoning)
     }

--- a/R/config.R
+++ b/R/config.R
@@ -1,6 +1,9 @@
 # App version — single source of truth
 SERAPEUM_VERSION <- "18.0.0"
 
+# Cost estimate for OpenAlex content API PDF download (USD per request)
+OA_CONTENT_DOWNLOAD_COST_USD <- 0.01
+
 #' Load configuration from YAML file or environment variables
 #' @param path Path to config file
 #' @return List of config values (from file, env vars, or NULL)

--- a/R/import_paper.R
+++ b/R/import_paper.R
@@ -61,7 +61,7 @@ import_single_paper <- function(con, notebook_id, abstract_row,
         tryCatch(
           log_oa_usage(con, "content_download",
                        paste0("content/works/", abs$paper_id, ".pdf"),
-                       dl$usage, cost_usd = 0.01),
+                       dl$usage, cost_usd = OA_CONTENT_DOWNLOAD_COST_USD),
           error = function(e) message("[import] Failed to log OA usage: ", e$message)
         )
       }

--- a/R/mod_cost_tracker.R
+++ b/R/mod_cost_tracker.R
@@ -314,7 +314,7 @@ build_latency_sparkline <- function(trend) {
   if (nrow(trend) < 2) return(NULL)
 
   max_ms <- max(trend$avg_latency_ms, na.rm = TRUE)
-  if (max_ms == 0) return(NULL)
+  if (!is.finite(max_ms) || max_ms <= 0) return(NULL)
 
   bar_heights <- (trend$avg_latency_ms / max_ms) * 40
 

--- a/R/mod_cost_tracker.R
+++ b/R/mod_cost_tracker.R
@@ -317,6 +317,7 @@ build_latency_sparkline <- function(trend) {
   if (!is.finite(max_ms) || max_ms <= 0) return(NULL)
 
   bar_heights <- (trend$avg_latency_ms / max_ms) * 40
+  bar_heights[is.na(bar_heights)] <- 0
 
   tags$div(
     class = "d-flex align-items-end gap-1",

--- a/R/mod_query_builder.R
+++ b/R/mod_query_builder.R
@@ -79,7 +79,7 @@ OUTPUT (valid JSON only, no markdown, no code fences):
       model <- resolve_model_for_operation(cfg, "query_build")
       req(provider, model)
 
-      if ((is.null(provider$api_key) || nchar(provider$api_key) == 0) && !is_local_provider(provider)) {
+      if ((is.null(provider$api_key) || is.na(provider$api_key) || !nzchar(provider$api_key)) && !is_local_provider(provider)) {
         showNotification(
           "OpenRouter API key not configured. Please go to Settings.",
           type = "warning",

--- a/R/mod_search_notebook.R
+++ b/R/mod_search_notebook.R
@@ -555,6 +555,7 @@ mod_search_notebook_server <- function(id, con, notebook_id, config, notebook_re
         source("R/db_migrations.R")
         source("R/db.R")
         source("R/interrupt.R")
+        source("R/config.R")       # For DEFAULT_CONFIG (used by import_single_paper)
         source("R/bulk_import.R")  # For write_import_progress / read_import_progress
         source("R/_ragnar.R")      # For chunk_with_ragnar()
         source("R/pdf.R")          # For download_pdf_from_url(), process_pdf(), sanitize_filename()
@@ -2872,7 +2873,7 @@ mod_search_notebook_server <- function(id, con, notebook_id, config, notebook_re
         provider_or <- provider_from_config(cfg, con())
         embed_model <- resolve_model_for_operation(cfg, "embedding")
 
-        if ((is.null(provider_or$api_key) || nchar(provider_or$api_key) == 0) && !is_local_provider(provider_or)) {
+        if ((is.null(provider_or$api_key) || is.na(provider_or$api_key) || !nzchar(provider_or$api_key)) && !is_local_provider(provider_or)) {
           showNotification("API key required for embedding (unless using a local provider)", type = "error")
           return()
         }

--- a/tests/testthat/test-cost-tracking.R
+++ b/tests/testthat/test-cost-tracking.R
@@ -1,4 +1,5 @@
 library(testthat)
+library(shiny)
 
 
 source_app("config.R")
@@ -264,4 +265,57 @@ test_that("log_cost returns NULL and warns on INSERT failure", {
   )
 
   expect_null(result)
+})
+
+# --- #223: build_latency_sparkline edge cases ---
+
+test_that("build_latency_sparkline returns NULL for all-NA latencies", {
+  trend <- data.frame(
+    date = Sys.Date() - 0:2,
+    avg_latency_ms = c(NA_real_, NA_real_, NA_real_),
+    call_count = c(1L, 1L, 1L)
+  )
+  expect_null(build_latency_sparkline(trend))
+})
+
+test_that("build_latency_sparkline returns NULL for all-zero latencies", {
+  trend <- data.frame(
+    date = Sys.Date() - 0:2,
+    avg_latency_ms = c(0, 0, 0),
+    call_count = c(1L, 1L, 1L)
+  )
+  expect_null(build_latency_sparkline(trend))
+})
+
+test_that("build_latency_sparkline handles mixed NA and valid values", {
+  trend <- data.frame(
+    date = Sys.Date() - 0:2,
+    avg_latency_ms = c(NA_real_, 500, 1000),
+    call_count = c(1L, 2L, 3L)
+  )
+  result <- build_latency_sparkline(trend)
+  expect_false(is.null(result))
+  expect_s3_class(result, "shiny.tag")
+})
+
+test_that("build_latency_sparkline returns sparkline for normal input", {
+  trend <- data.frame(
+    date = Sys.Date() - 0:3,
+    avg_latency_ms = c(200, 500, 300, 800),
+    call_count = c(5L, 3L, 4L, 2L)
+  )
+  result <- build_latency_sparkline(trend)
+  expect_false(is.null(result))
+  expect_s3_class(result, "shiny.tag")
+  rendered <- as.character(result)
+  expect_match(rendered, "d-flex")
+})
+
+test_that("build_latency_sparkline returns NULL for single-row trend", {
+  trend <- data.frame(
+    date = Sys.Date(),
+    avg_latency_ms = 500,
+    call_count = 3L
+  )
+  expect_null(build_latency_sparkline(trend))
 })

--- a/tests/testthat/test-cost-tracking.R
+++ b/tests/testthat/test-cost-tracking.R
@@ -296,6 +296,7 @@ test_that("build_latency_sparkline handles mixed NA and valid values", {
   result <- build_latency_sparkline(trend)
   expect_false(is.null(result))
   expect_s3_class(result, "shiny.tag")
+  expect_false(grepl("NApx", as.character(result)))
 })
 
 test_that("build_latency_sparkline returns sparkline for normal input", {

--- a/tests/testthat/test-extract-message-content.R
+++ b/tests/testthat/test-extract-message-content.R
@@ -28,6 +28,17 @@ test_that("extract_message_content returns empty string when no reasoning fallba
   expect_equal(extract_message_content(msg), "")
 })
 
+test_that("extract_message_content falls through character(0) to reasoning", {
+  msg <- list(content = character(0), reasoning = "fallback reasoning")
+  expect_equal(extract_message_content(msg), "fallback reasoning")
+})
+
+test_that("extract_message_content handles character(0) with no reasoning", {
+  msg <- list(content = character(0))
+  # character(0) is empty, no reasoning → returns content as-is
+  expect_equal(extract_message_content(msg), character(0))
+})
+
 test_that("extract_message_content handles multi-element character vector", {
   # This was the bug — nchar() on a vector yields a vector, if() errors
   msg <- list(content = c("Hello", "World"))

--- a/tests/testthat/test-extract-message-content.R
+++ b/tests/testthat/test-extract-message-content.R
@@ -1,0 +1,51 @@
+library(testthat)
+
+source_app("api_openrouter.R")
+
+test_that("extract_message_content returns normal string content", {
+  msg <- list(content = "Hello, world!")
+  expect_equal(extract_message_content(msg), "Hello, world!")
+})
+
+test_that("extract_message_content returns reasoning when content is NULL", {
+  msg <- list(content = NULL, reasoning = "I reasoned this.")
+  expect_equal(extract_message_content(msg), "I reasoned this.")
+})
+
+test_that("extract_message_content returns NULL when content and reasoning are NULL", {
+  msg <- list(content = NULL, reasoning = NULL)
+  expect_null(extract_message_content(msg))
+})
+
+test_that("extract_message_content falls through empty string to reasoning", {
+  msg <- list(content = "", reasoning = "fallback reasoning")
+  expect_equal(extract_message_content(msg), "fallback reasoning")
+})
+
+test_that("extract_message_content returns empty string when no reasoning fallback", {
+  msg <- list(content = "")
+  # Content is empty, no reasoning → falls through and returns content as-is
+  expect_equal(extract_message_content(msg), "")
+})
+
+test_that("extract_message_content handles multi-element character vector", {
+  # This was the bug — nchar() on a vector yields a vector, if() errors
+  msg <- list(content = c("Hello", "World"))
+  expect_equal(extract_message_content(msg), c("Hello", "World"))
+})
+
+test_that("extract_message_content concatenates list-of-parts content", {
+  msg <- list(content = list(
+    list(text = "Part one"),
+    list(text = "Part two")
+  ))
+  expect_equal(extract_message_content(msg), "Part one\nPart two")
+})
+
+test_that("extract_message_content handles mixed list parts", {
+  msg <- list(content = list(
+    list(text = "Structured"),
+    "plain string"
+  ))
+  expect_equal(extract_message_content(msg), "Structured\nplain string")
+})


### PR DESCRIPTION
## Summary

- **#128** (notebook descriptions): Closed as already resolved — tooltips exist on all sidebar buttons
- **#221** (keyword filter return type): Closed as already resolved — caller destructures correctly
- **#223** (sparkline crash on all-NA): Fixed `max(-Inf)` guard with `is.finite()` check
- **#220** (NA guard on api_key): Added `is.na()` check before `nchar()` call
- **#224** (magic number): Extracted `cost_usd = 0.01` to named constant `OA_CONTENT_DOWNLOAD_COST_USD` in config.R
- **#222** (nchar multi-element vector): Wrapped `nchar(content) == 0` in `all()` to prevent `if()` error on vector input

## Test plan

- [x] 5 new tests for `build_latency_sparkline` edge cases (all-NA, all-zero, mixed, normal, single-row)
- [x] 8 new tests for `extract_message_content` (normal, NULL+reasoning, NULL-no-reasoning, empty string, multi-element vector, list-of-parts, mixed parts)
- [x] Full test suite passes (0 failures in new/modified tests)
- [x] App startup smoke test passes