### PR TITLE
chore: add Ragnar Bedrock planning beans

### DIFF
--- a/.beans.yml
+++ b/.beans.yml
@@ -1,0 +1,6 @@
+beans:
+    path: .beans
+    prefix: serapeum-
+    id_length: 4
+    default_status: todo
+    default_type: task

--- a/.beans/serapeum-521b--evaluate-ragnar-database-backend-support.md
+++ b/.beans/serapeum-521b--evaluate-ragnar-database-backend-support.md
@@ -1,0 +1,40 @@
+---
+# serapeum-521b
+title: Evaluate Ragnar database backend support
+status: todo
+type: task
+priority: deferred
+tags:
+    - ragnar
+    - database
+    - architecture
+    - investigation
+created_at: 2026-05-24T17:19:32Z
+updated_at: 2026-05-24T17:19:32Z
+parent: serapeum-9vzz
+---
+
+## Context
+
+Serapeum is currently built around local DuckDB persistence. Ragnar may have assumptions or extension points around storage/vector stores that could affect whether Serapeum should keep DuckDB as the canonical store, add another backend, or only use Ragnar for model/RAG orchestration.
+
+## Research questions
+
+- What database, vector store, or document-store backends does Ragnar support today?
+- Does Ragnar expose backend abstractions that Serapeum can plug into, or is backend choice fixed by Ragnar internals?
+- Can Ragnar operate with DuckDB as the durable local store, either directly or through an adapter layer?
+- If alternate backends are supported, what are the tradeoffs for local-first use, reproducibility, installation burden, and federal/locked-down environments?
+- Which Serapeum data boundaries must remain stable regardless of Ragnar backend support?
+
+## Acceptance criteria
+
+- Produce a short backend capability matrix covering Ragnar-supported persistence/vector backends and DuckDB compatibility.
+- Recommend one of:
+  1. Keep DuckDB canonical and use Ragnar only above the persistence layer.
+  2. Add a Ragnar-compatible adapter while retaining DuckDB as the source of truth.
+  3. Plan a broader backend abstraction if Ragnar support makes that worthwhile.
+- File any implementation issues that follow from the recommendation.
+
+## Guardrail
+
+Do not assume Ragnar supports arbitrary database backends. Verify from package docs/source before designing around it.

--- a/.beans/serapeum-9vzz--plan-ragnar-native-bedrock-adoption.md
+++ b/.beans/serapeum-9vzz--plan-ragnar-native-bedrock-adoption.md
@@ -1,0 +1,42 @@
+---
+# serapeum-9vzz
+title: Plan Ragnar-native Bedrock adoption
+status: todo
+type: milestone
+priority: deferred
+tags:
+    - ragnar
+    - bedrock
+    - llm
+    - future-milestone
+created_at: 2026-05-24T17:19:32Z
+updated_at: 2026-05-24T17:19:32Z
+---
+
+## Context
+
+Ragnar can natively use AWS Bedrock-hosted models. Serapeum currently has OpenRouter-oriented LLM access, so Bedrock support should be planned as a future milestone rather than bolted on ad hoc.
+
+## Outcome
+
+Create a defensible integration plan for using Ragnar-native Bedrock models inside Serapeum while preserving local-first behavior, reproducibility, and clear separation between retrieval, model routing, and persistence.
+
+## Scope
+
+- Inventory Ragnar's current model-provider APIs for Bedrock chat/completion and embedding workflows.
+- Crosswalk Ragnar's Bedrock support against Serapeum's existing OpenRouter client boundaries.
+- Decide whether Bedrock is a parallel provider option, a Ragnar-backed replacement path, or a feature-gated experimental backend.
+- Identify credential/configuration requirements and avoid storing secrets in project files.
+- Define test strategy with mocks or dry-run provider probes so this remains deterministic in CI/local development.
+- Document required changes in `docs/plans/` before implementation.
+
+## Acceptance criteria
+
+- A short design note exists describing the recommended Ragnar/Bedrock architecture.
+- The plan identifies which Serapeum modules/functions would change and which should stay provider-agnostic.
+- Credential handling is specified without committing secrets.
+- Follow-up implementation issues are created if the plan recommends proceeding.
+
+## Notes
+
+This is intentionally a future milestone. Do not implement provider changes until the design questions are answered.


### PR DESCRIPTION
## Summary
- Add a future milestone bean for planning Ragnar-native Bedrock model support.
- Add a child investigation bean for Ragnar database/backend support and DuckDB compatibility.
- Commit the previously untracked Beans config so the tracker is durable.

## Verification
- `beans show serapeum-9vzz`
- `beans show serapeum-521b`
- `beans check`
